### PR TITLE
chore: add hourly schedule trigger, remove need for per-addon DOCS_DISPATCH_TOKEN

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,10 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
+  schedule:
+    # Rebuild hourly to pick up changes from addon repos
+    # Replaces the per-addon trigger-docs.yml push-based approach
+    - cron: '17 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -63,6 +67,8 @@ jobs:
             [multisite-ultimate-vat]=ultimate-multisite-vat
             [multisite-ultimate-admin-page-creator]=ultimate-multisite-admin-page-creator
             [ultimate-multisite-addon-template]=ultimate-multisite-addon-template
+            [ultimate-multisite-emails]=ultimate-multisite-emails
+            [multisite-ultimate-metrics-and-onboarding]=ultimate-multisite-metrics-and-onboarding
             [tutor-multisite-compatibilty]=tutor-multisite-compatibility
             [material-wp]=material-wp
           )


### PR DESCRIPTION
## Summary

- Adds hourly cron schedule (`17 * * * *`) to `deploy-docs.yml` so docs rebuild automatically when addon repos change
- Replaces the per-addon `trigger-docs.yml` push-based approach that required `DOCS_DISPATCH_TOKEN` as a secret in every addon repo (7 repos were failing because the token was missing)
- Adds 2 missing addons to the checkout list: `ultimate-multisite-emails`, `multisite-ultimate-metrics-and-onboarding`
- Existing triggers preserved: push-on-main and manual workflow_dispatch

After merging this, the `trigger-docs.yml` workflow can be removed from all addon repos — it's no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build process to run on a scheduled basis, ensuring more frequent updates to documentation.

* **New Features**
  * Extended documentation to include two additional addon modules in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->