### PR TITLE
chore: upgrade GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,10 +13,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Checkout main plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Ultimate-Multisite/ultimate-multisite
           path: ultimate-multisite

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -22,10 +22,10 @@ jobs:
   translate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions action versions to eliminate Node.js 20 deprecation warnings ahead of the June 2, 2026 forced migration deadline.

### Changes

| File | Action | Before | After |
|------|--------|--------|-------|
| `deploy-docs.yml` | `actions/checkout` | `@v4` | `@v6` |
| `deploy-docs.yml` | `actions/setup-node` | `@v4` | `@v6` |
| `translate.yml` | `actions/checkout` | `@v4` | `@v6` |
| `translate.yml` | `actions/setup-node` | `@v4` | `@v6` |

`shivammathur/setup-php@v2` is already on Node 24 — no change needed.
`softprops/action-gh-release` is not used in these workflows — no env var needed.

## Verification

After merging, trigger a workflow run and confirm no Node.js 20 deprecation warnings appear in the annotations.

Resolves #15