### PR TITLE
docs: add Gratis AI Agent v1.5.0 documentation

### DIFF
--- a/docs/developer/integration-guide/plugin-management-abilities.md
+++ b/docs/developer/integration-guide/plugin-management-abilities.md
@@ -1,0 +1,140 @@
+---
+title: "Plugin Management Abilities"
+sidebar_position: 4
+---
+
+# Plugin Management Abilities
+
+Gratis AI Agent v1.5.0 ships with **7 plugin management abilities** that the AI assistant can invoke during a conversation. These abilities provide programmatic control over WordPress plugins installed through the [Plugin Builder & Sandbox System](../../user-guide/administration/plugin-builder-and-sandbox).
+
+## Abilities Overview
+
+| Ability | Slug | Description |
+|---|---|---|
+| List Plugins | `list_plugins` | Returns a list of plugins in the sandbox store with their status. |
+| Get Plugin | `get_plugin` | Retrieves metadata and source code for a specific plugin by slug. |
+| Create Plugin | `create_plugin` | Generates a new plugin from a description and stores it in the sandbox. |
+| Update Plugin | `update_plugin` | Replaces a plugin's source code with a new version. |
+| Delete Plugin | `delete_plugin` | Removes a plugin from the sandbox store. Deactivates first. |
+| Install Plugin | `install_plugin` | Deploys a sandboxed plugin to the live WordPress plugin directory. |
+| Activate Plugin | `activate_plugin` | Activates a sandboxed plugin in the wp-env sandbox environment. |
+
+## Plugin Installer API
+
+The plugin installer handles file system operations when deploying or removing plugins. Key behaviours:
+
+- **Path validation**: All plugin paths are validated against the allowed plugin directory before any file write. Directory traversal attempts are rejected.
+- **Multi-file install**: A plugin may consist of multiple files. The installer creates the plugin directory and writes all files atomically.
+- **Update**: Replaces existing plugin files. Deactivates the plugin before writing to avoid partial-state errors.
+- **Delete by slug**: Locates the plugin directory by slug, deactivates across all sites, then removes the directory.
+
+### Registering a Custom Install Handler
+
+You can hook into the install lifecycle using the `gratis_ai_plugin_installer_before_install` and `gratis_ai_plugin_installer_after_install` actions:
+
+```php
+add_action('gratis_ai_plugin_installer_before_install', function(string $slug, array $files): void {
+    // $slug: the plugin's directory name
+    // $files: associative array of relative path => file content
+    error_log("Installing plugin: {$slug} with " . count($files) . " files.");
+}, 10, 2);
+
+add_action('gratis_ai_plugin_installer_after_install', function(string $slug, bool $success): void {
+    if ($success) {
+        error_log("Plugin {$slug} installed successfully.");
+    }
+}, 10, 2);
+```
+
+## Ecosystem Registry
+
+Abilities are registered through the **plugin ecosystem registry**. The registry maps ability slugs to their handler classes and exposes them to the AI agent's tool dispatcher.
+
+To register a custom plugin management ability:
+
+```php
+add_filter('gratis_ai_plugin_abilities', function(array $abilities): array {
+    $abilities['my_custom_ability'] = [
+        'class'       => My_Custom_Plugin_Ability::class,
+        'label'       => 'My Custom Ability',
+        'description' => 'Does something useful with plugins.',
+    ];
+    return $abilities;
+});
+```
+
+Your ability class must implement the `Gratis_AI_Ability_Interface`:
+
+```php
+class My_Custom_Plugin_Ability implements Gratis_AI_Ability_Interface {
+
+    public function get_slug(): string {
+        return 'my_custom_ability';
+    }
+
+    public function get_schema(): array {
+        return [
+            'name'        => 'my_custom_ability',
+            'description' => 'Does something useful with plugins.',
+            'parameters'  => [
+                'type'       => 'object',
+                'properties' => [
+                    'slug' => [
+                        'type'        => 'string',
+                        'description' => 'The plugin slug to operate on.',
+                    ],
+                ],
+                'required' => ['slug'],
+            ],
+        ];
+    }
+
+    public function execute(array $params): array {
+        $slug = sanitize_key($params['slug'] ?? '');
+        // ... your implementation ...
+        return ['success' => true, 'slug' => $slug];
+    }
+}
+```
+
+## HookScanner Integration
+
+The `create_plugin` and `update_plugin` abilities automatically run the **HookScanner** against newly generated code. HookScanner returns a list of WordPress action and filter hooks registered by the plugin.
+
+To retrieve HookScanner results programmatically:
+
+```php
+$scanner = new Gratis_AI_Hook_Scanner();
+$hooks   = $scanner->scan_plugin_slug('my-generated-plugin');
+
+foreach ($hooks['actions'] as $hook) {
+    echo "Action: {$hook['hook']} — callback: {$hook['callback']}\n";
+}
+
+foreach ($hooks['filters'] as $hook) {
+    echo "Filter: {$hook['hook']} — callback: {$hook['callback']}\n";
+}
+```
+
+HookScanner skips `vendor/` and `node_modules/` directories automatically.
+
+## Async Job Architecture
+
+Long-running plugin operations (generate, install) are dispatched as **async jobs** with live progress tracking. The AI chat interface polls for progress and streams status updates to the user:
+
+1. **Dispatch** — the ability creates an async job and returns a job ID.
+2. **Poll** — the agent polls `gratis_ai_job_status($job_id)` every 2 seconds.
+3. **Stream** — intermediate progress messages are pushed to the chat thread.
+4. **Complete** — the final result (success or error) is returned and displayed.
+
+To hook into job lifecycle events:
+
+```php
+add_action('gratis_ai_job_started', function(string $job_id, string $ability_slug): void {
+    error_log("Job {$job_id} started for ability: {$ability_slug}");
+}, 10, 2);
+
+add_action('gratis_ai_job_completed', function(string $job_id, array $result): void {
+    error_log("Job {$job_id} completed. Success: " . ($result['success'] ? 'yes' : 'no'));
+}, 10, 2);
+```

--- a/docs/user-guide/administration/gratis-ai-agent-settings.md
+++ b/docs/user-guide/administration/gratis-ai-agent-settings.md
@@ -1,0 +1,74 @@
+---
+title: "Gratis AI Agent Settings"
+sidebar_position: 22
+---
+
+# Gratis AI Agent Settings
+
+The **Settings → Advanced** screen in Gratis AI Agent provides administrator-level configuration for backend integrations introduced in v1.5.0. This page documents the **Feedback Endpoint** fields and their expected format.
+
+## Accessing Settings
+
+1. In the WordPress admin, go to **Gratis AI Agent → Settings**.
+2. Click the **Advanced** tab.
+
+## Feedback Endpoint Configuration
+
+The feedback endpoint receives POST requests from the AI agent whenever a user submits feedback via the thumbs-down button, the auto-prompt banner, or the `/report-issue` command.
+
+| Field | Description |
+|---|---|
+| **Feedback Endpoint URL** | The URL that receives feedback submissions as HTTP POST requests with a JSON body. |
+| **Feedback API Key** | A bearer token sent in the `Authorization` header of each feedback request. Leave blank if your endpoint does not require authentication. |
+
+### Expected JSON Payload
+
+Your feedback endpoint must accept a JSON body with at least the following fields:
+
+```json
+{
+  "message_id": "msg_abc123",
+  "conversation_id": "conv_xyz789",
+  "feedback_text": "The answer was incorrect about pricing.",
+  "triage_category": "factual_error"
+}
+```
+
+Additional fields may be present in the payload depending on the conversation context.
+
+### `triage_category` Values
+
+The AI triage layer assigns one of the following values to `triage_category` before forwarding the payload:
+
+| Value | Meaning |
+|---|---|
+| `factual_error` | The assistant provided incorrect factual information. |
+| `unhelpful_answer` | The response was technically correct but not useful. |
+| `inappropriate_content` | The response contained content that should not be shown to users. |
+| `other` | The feedback did not match a known category. |
+
+### Authentication
+
+If your endpoint requires authentication, set the **Feedback API Key** field to your bearer token. The agent sends:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+If the **Feedback API Key** field is empty, no `Authorization` header is sent.
+
+### Disabling Feedback Collection
+
+Leave both the **Feedback Endpoint URL** and **Feedback API Key** fields blank. The thumbs-down button and feedback UI remain visible to users, but submissions are not forwarded to any external service.
+
+## Brave Search API Key
+
+Also on the **Advanced** tab, the **Brave Search API Key** field enables the [Internet Search](../configuration/internet-search) ability.
+
+| Field | Description |
+|---|---|
+| **Brave Search API Key** | Your API key from the Brave Search developer dashboard. Required to enable internet search in the AI assistant. |
+
+The field label includes a clickable link to the Brave Search API sign-up page. Leave blank to disable internet search.
+
+See [Internet Search](../configuration/internet-search) for end-user documentation on this feature.

--- a/docs/user-guide/administration/plugin-builder-and-sandbox.md
+++ b/docs/user-guide/administration/plugin-builder-and-sandbox.md
@@ -1,0 +1,103 @@
+---
+title: "Plugin Builder & Sandbox"
+sidebar_position: 21
+---
+
+# Plugin Builder & Sandbox
+
+Gratis AI Agent v1.5.0 introduces the **Plugin Builder & Sandbox System**, which lets the AI assistant generate, activate, and manage WordPress plugins on your network — all through a safe, isolated sandbox environment.
+
+## Overview
+
+The Plugin Builder enables the AI assistant to write custom WordPress plugins in response to natural language requests. Generated plugins are validated, stored, and activated inside a sandbox layer before they ever affect live site functionality.
+
+Use cases include:
+
+- Generating lightweight utility plugins without developer involvement.
+- Prototyping features that require WordPress hooks or custom post types.
+- Creating short-lived automation scripts for batch operations.
+
+## Generating a Plugin via AI
+
+To generate a plugin, open the Gratis AI Agent chat interface and describe what you need. For example:
+
+> "Create a plugin that adds a custom admin notice on the dashboard."
+
+The AI will:
+
+1. Produce the plugin PHP code using structured code generation.
+2. Validate the output for syntax errors and unsafe patterns.
+3. Save the generated plugin to the sandbox store.
+4. Return a confirmation with the plugin slug and an **Activate in Sandbox** button.
+
+You can refine the result by following up in the same conversation thread before activating.
+
+## Sandbox Activation
+
+Activating a generated plugin in the sandbox is distinct from activating it on the live network. The sandbox:
+
+- Runs the plugin in an isolated WordPress environment (wp-env).
+- Captures any PHP errors, warnings, or hook conflicts.
+- Reports the activation result back in the chat interface.
+
+To activate a plugin in the sandbox, click the **Activate in Sandbox** button in the AI chat response, or use the slash command:
+
+```
+/activate-plugin <plugin-slug>
+```
+
+A status message confirms whether activation succeeded or failed. On failure, the error log is displayed in the chat thread.
+
+## Managing Generated Plugins
+
+Generated plugins are listed in **Gratis AI Agent → Plugin Builder → Manage Plugins**. From this screen you can:
+
+| Action | Description |
+|---|---|
+| **View source** | Review the full plugin PHP code. |
+| **Re-activate in sandbox** | Re-run the sandbox activation check. |
+| **Install on network** | Deploy the plugin to the live network (requires manual confirmation). |
+| **Update** | Provide a new version via the AI, replacing the existing code. |
+| **Delete** | Remove the plugin from the sandbox store. Deactivates it from all sites first. |
+
+:::warning
+**Install on network** deploys the generated plugin to your live WordPress multisite. Review the plugin code before proceeding. Gratis AI Agent will prompt for confirmation before completing a live install.
+:::
+
+## Installing a Generated Plugin on the Network
+
+When you are satisfied with a sandboxed plugin, you can install it on the live network:
+
+1. Go to **Gratis AI Agent → Plugin Builder → Manage Plugins**.
+2. Click **Install on Network** next to the plugin you want to deploy.
+3. Confirm the dialog. The plugin is installed to `wp-content/plugins/` and network-activated.
+
+Alternatively, use the slash command in the chat interface:
+
+```
+/install-plugin <plugin-slug>
+```
+
+## Plugin Updates
+
+To update a generated plugin, describe the change to the AI assistant in a new conversation:
+
+> "Update the dashboard-notice plugin to only show the notice to administrators."
+
+The AI generates a new version, which appears in the sandbox alongside the current version. You review the diff and confirm before the update is applied.
+
+## HookScanner Integration
+
+The Plugin Builder uses an integrated **HookScanner** to analyse the hooks and filters registered by each generated plugin. HookScanner output is shown in the chat response and includes:
+
+- Action hooks registered (`add_action` calls).
+- Filter hooks registered (`add_filter` calls).
+- Any hooks found in plugin dependencies (skips `vendor/` and `node_modules/` directories).
+
+This helps you understand a plugin's behaviour before activating it.
+
+## Security Considerations
+
+- Generated plugins are stored separately from manually installed plugins and are not accessible via the standard WordPress plugin management screen until you explicitly install them on the network.
+- The sandbox uses path validation to prevent directory traversal when writing plugin files.
+- Plugins with dangerous function calls (e.g., `eval`, `exec`, `system`) are flagged during validation and will not be activated.

--- a/docs/user-guide/configuration/feedback-and-issue-reporting.md
+++ b/docs/user-guide/configuration/feedback-and-issue-reporting.md
@@ -1,0 +1,68 @@
+---
+title: "Customer Feedback & Issue Reporting"
+sidebar_position: 25
+---
+
+# Customer Feedback & Issue Reporting
+
+Gratis AI Agent v1.5.0 introduces a built-in feedback and issue reporting system that lets end users flag unhelpful responses and report problems directly from the chat interface. This system includes consent management, an automated reporting command, and AI-assisted triage on the backend.
+
+## Thumbs-Down Button
+
+Every message sent by the AI assistant displays a **thumbs-down** (👎) button. When a user clicks it, they can mark a response as unhelpful or incorrect.
+
+- The button appears on hover next to each assistant message.
+- Clicking it opens the **Feedback Consent Modal**.
+- The feedback is associated with the conversation thread and the specific message.
+
+## Feedback Consent Modal
+
+When a user clicks the thumbs-down button, a consent modal appears before any data is sent. The modal:
+
+- Explains what information will be collected (conversation excerpt, browser context).
+- Asks the user to confirm they consent to sharing this data.
+- Provides a free-text field for the user to describe what went wrong.
+- Offers a **Cancel** option to dismiss without submitting.
+
+No feedback is recorded until the user explicitly confirms.
+
+## Auto-Prompt Feedback Banner
+
+At the end of a conversation, the assistant may display an **auto-prompt feedback banner** — a non-intrusive message asking whether the session was helpful.
+
+This banner appears automatically based on conversation length and outcome heuristics. It links to the same feedback flow as the thumbs-down button. Users can dismiss the banner without providing feedback.
+
+## /report-issue Slash Command
+
+Users can trigger the feedback flow directly by typing `/report-issue` in the chat input. This command:
+
+- Opens the Feedback Consent Modal immediately.
+- Pre-populates the description field with context about the current conversation.
+- Allows users to add additional detail before submitting.
+
+The `/report-issue` command is available in all chat modes (inline, floating widget, full-screen).
+
+## AI-Assisted Triage
+
+Submitted feedback is routed to an AI triage layer that:
+
+- Categorises the report (factual error, unhelpful answer, inappropriate content, etc.).
+- Attaches relevant conversation metadata.
+- Forwards the triage summary to the configured **Feedback Endpoint** (see [Settings > Advanced](#settings-advanced)).
+
+This reduces manual review time by surfacing the most critical issues first.
+
+## Settings > Advanced {#settings-advanced}
+
+To enable the feedback backend, configure the following fields under **Gratis AI Agent → Settings → Advanced**:
+
+| Field | Description |
+|---|---|
+| **Feedback Endpoint URL** | The URL that receives POST requests with feedback payloads (JSON). |
+| **Feedback API Key** | Bearer token sent in the `Authorization` header for authenticating feedback submissions. |
+
+Leave both fields blank to disable feedback collection. Individual feedback buttons remain visible to users, but submissions will not be forwarded.
+
+:::tip
+The feedback endpoint must accept a JSON body with at least `message_id`, `conversation_id`, `feedback_text`, and `triage_category` fields. See your endpoint provider's documentation for the expected schema.
+:::

--- a/docs/user-guide/configuration/internet-search.md
+++ b/docs/user-guide/configuration/internet-search.md
@@ -1,0 +1,44 @@
+---
+title: "Internet Search"
+sidebar_position: 26
+---
+
+# Internet Search
+
+Gratis AI Agent v1.5.0 adds an **Internet Search** ability that lets the AI assistant retrieve up-to-date information from the web during a conversation. This is powered by the [Brave Search API](https://brave.com/search/api/).
+
+## How It Works
+
+When internet search is enabled, the assistant can automatically query Brave Search when it determines that a question requires current or external information — for example, recent news, live pricing, or documentation that may have changed since the model's training cutoff.
+
+Results are retrieved in real time and injected into the assistant's context before it generates a response. The assistant indicates when it has used search results to answer a question.
+
+## Enabling Internet Search
+
+Internet search requires a Brave Search API key. To configure it:
+
+1. Go to **Gratis AI Agent → Settings → Advanced**.
+2. Locate the **Brave Search API Key** field.
+3. Enter your API key. The Brave Search API sign-up link is displayed next to the field as a clickable link.
+4. Click **Save Settings**.
+
+Once the key is saved, the Internet Search ability is automatically available to the assistant.
+
+## Obtaining a Brave Search API Key
+
+1. Visit the [Brave Search API page](https://brave.com/search/api/) (link also shown in the settings field).
+2. Sign up for a plan. A free tier is available with a monthly request limit.
+3. Copy your API key from the Brave Search developer dashboard.
+4. Paste it into the **Brave Search API Key** field in Gratis AI Agent settings.
+
+## Disabling Internet Search
+
+Remove the API key from the **Brave Search API Key** field and save. The Internet Search ability will no longer be offered to the assistant.
+
+:::note
+Internet search adds latency to responses because the assistant must wait for search results before generating an answer. For time-sensitive use cases, consider whether real-time search is necessary or whether the assistant's built-in knowledge is sufficient.
+:::
+
+## Usage Limits
+
+Usage is billed by Brave Search based on the number of queries made. Each AI response that triggers a search counts as one query. Monitor your usage in the [Brave Search developer dashboard](https://brave.com/search/api/) to avoid unexpected charges.

--- a/sidebars.js
+++ b/sidebars.js
@@ -27,6 +27,8 @@ const sidebars = {
         'user-guide/administration/managing-memberships',
         'user-guide/administration/managing-payments-and-invoices',
         'user-guide/administration/managing-system-emails',
+        'user-guide/administration/plugin-builder-and-sandbox',
+        'user-guide/administration/gratis-ai-agent-settings',
       ],
     },
     {
@@ -41,6 +43,8 @@ const sidebars = {
         'user-guide/configuration/managing-shareable-links-for-plans',
         'user-guide/configuration/customizing-your-registration-form',
         'user-guide/configuration/the-registration-flow',
+        'user-guide/configuration/feedback-and-issue-reporting',
+        'user-guide/configuration/internet-search',
       ],
     },
     {
@@ -191,6 +195,7 @@ const sidebars = {
         'developer/integration-guide/index',
         'developer/integration-guide/custom-gateway',
         'developer/integration-guide/webhooks',
+        'developer/integration-guide/plugin-management-abilities',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Documents the features introduced in Gratis AI Agent v1.5.0:

- **Customer Feedback & Issue Reporting** (`user-guide/configuration/`) — thumbs-down button, feedback consent modal, auto-prompt banner, `/report-issue` slash command, AI-assisted triage
- **Internet Search** (`user-guide/configuration/`) — Brave Search API integration, enable/disable steps, usage limits
- **Plugin Builder & Sandbox** (`user-guide/administration/`) — AI plugin generation, sandbox activation, install/update/delete, HookScanner, security notes
- **Gratis AI Agent Settings** (`user-guide/administration/`) — admin Settings > Advanced: feedback endpoint URL/API key and Brave Search API key
- **Plugin Management Abilities** (`developer/integration-guide/`) — 7 plugin management abilities, plugin installer/updater API, ecosystem registry, HookScanner, async job architecture

All 5 new pages added to their respective sidebar sections in `sidebars.js`.

Resolves #17