### PR TITLE
docs: document v2.6.1 features — template selection, BerlinDB increment_item(), Cloudflare Custom Hostnames

### DIFF
--- a/docs/developer/code-examples/index.md
+++ b/docs/developer/code-examples/index.md
@@ -272,3 +272,99 @@ class Advanced_Limitations {
 
 new Advanced_Limitations();
 ```
+
+## BerlinDB Atomic Counter with `increment_item()`
+
+Ultimate Multisite v2.6.1 added an `increment_item()` method to the BerlinDB `Query` class. Use it to perform safe, atomic increments on numeric columns without read-modify-write races — useful for counters, usage quotas, and rate-limiting checks that run under concurrent requests.
+
+### Method signature
+
+```php
+/**
+ * Atomically increment a numeric column for a specific item.
+ *
+ * @param int    $item_id   Primary key of the row to update.
+ * @param string $column    Column name to increment (must be numeric).
+ * @param int    $amount    Amount to add. Use a negative value to decrement.
+ *                          Defaults to 1.
+ * @return bool True on success, false on failure or if the column is invalid.
+ */
+public function increment_item( int $item_id, string $column, int $amount = 1 ): bool;
+```
+
+### Basic usage
+
+```php
+// Add 1 to the `api_calls` column for membership ID 42.
+$memberships = new WP_Ultimo\Database\Memberships\Memberships_Query();
+$memberships->increment_item( 42, 'api_calls' );
+
+// Add 5 to a usage counter.
+$memberships->increment_item( 42, 'api_calls', 5 );
+
+// Decrement (subtract 1).
+$memberships->increment_item( 42, 'api_calls', -1 );
+```
+
+### Tracking API usage per membership
+
+A practical pattern for enforcing per-membership API rate limits:
+
+```php
+class Membership_API_Limiter {
+
+    /** Maximum API calls allowed per billing cycle. */
+    const LIMIT = 500;
+
+    public function __construct() {
+        add_filter( 'wu_is_api_enabled', [ $this, 'check_and_count' ], 10, 2 );
+    }
+
+    /**
+     * Reject the request if the membership is over the limit;
+     * otherwise count the call atomically.
+     *
+     * @param bool   $enabled
+     * @param object $context  Object with a get_membership_id() method.
+     * @return bool
+     */
+    public function check_and_count( bool $enabled, $context ): bool {
+        if ( ! $enabled ) {
+            return false;
+        }
+
+        $membership_id = $context->get_membership_id();
+
+        $memberships = new WP_Ultimo\Database\Memberships\Memberships_Query();
+        $membership  = $memberships->get_item( $membership_id );
+
+        if ( ! $membership ) {
+            return false;
+        }
+
+        if ( (int) $membership->api_calls >= self::LIMIT ) {
+            return false;  // Over quota — reject.
+        }
+
+        // Atomic increment: safe under concurrent requests.
+        $memberships->increment_item( $membership_id, 'api_calls' );
+
+        return true;
+    }
+}
+
+new Membership_API_Limiter();
+```
+
+### Why `increment_item()` instead of `update_item()`
+
+A naive read-modify-write approach is unsafe under concurrent requests:
+
+```php
+// UNSAFE — race condition between read and write.
+$membership = $memberships->get_item( $membership_id );
+$new_count  = (int) $membership->api_calls + 1;
+$memberships->update_item( $membership_id, [ 'api_calls' => $new_count ] );
+```
+
+Two simultaneous requests can read the same value and both write back the same incremented result, losing one count. `increment_item()` delegates the arithmetic to the database engine with a single `UPDATE ... SET column = column + ?` statement, making the operation inherently atomic.

--- a/docs/user-guide/configuration/checkout-forms.md
+++ b/docs/user-guide/configuration/checkout-forms.md
@@ -19,6 +19,8 @@ If you want to create a new one, just click Add Checkout Form on the top of the 
 
 You can select one of these three options as your starting point: single step, multi-step or blank. Then, click to Go to the Editor.
 
+When you choose **single step** or **multi-step** as your starting point, the form template now includes a **Template Selection** field by default. This field lets your customers pick a site template during the registration process. You can leave it in place, remove it, or reposition it like any other field in the editor.
+
 ![Checkout Form editor](/img/config/checkout-form-editor.png)
 
 Alternatively, you can edit or duplicate the forms you already have by clicking on the options below its name. There, you will also find the options to copy the form's shortcode or to delete the form.
@@ -154,3 +156,26 @@ You can also pre-select a product and billing period through the URL. Ultimate M
   * `/register/premium` — Pre-selects the "Premium" product only
   * `/register/premium/12` — Pre-selects the product and 12-month duration
   * `/register/premium/1/year` — Pre-selects the product with a 1-year duration
+
+### The Template Selection Field
+
+The **Template Selection** field lets customers choose a site template during checkout. It is now included by default in the **single step** and **multi-step** checkout form templates added in Ultimate Multisite v2.6.1.
+
+#### Adding the field manually
+
+If you are working with a form that was created before v2.6.1, or started from a blank template:
+
+1. Go to **Ultimate Multisite > Checkout Forms** and edit your checkout form.
+2. In the step where site details are collected, click **Add new Field**.
+3. Select **Template Selection** from the field type dialog.
+4. Configure the field:
+   - **Label** — The heading customers see above the template grid (e.g. "Choose a site template").
+   - **Required** — Whether customers must select a template before proceeding.
+
+#### How it works
+
+When a customer picks a template during checkout, Ultimate Multisite uses it when provisioning their new site. The templates shown come from your **Site Templates** list (**Ultimate Multisite > Site Templates**). Only templates marked as available to customers appear here.
+
+#### Removing the field
+
+If you do not offer site templates, remove the Template Selection field from your form. Customers will then receive whichever default template is configured under **Ultimate Multisite > Settings > Site Templates**.

--- a/docs/user-guide/host-integrations/cloudflare.md
+++ b/docs/user-guide/host-integrations/cloudflare.md
@@ -75,9 +75,35 @@ The integration enhances the DNS record display in the Ultimate Multisite admin 
 2. Displaying whether records are proxied or not
 3. Showing additional information about the DNS records
 
+## Cloudflare Custom Hostnames
+
+**Cloudflare Custom Hostnames** (previously called "Cloudflare for SaaS") is a Cloudflare feature that allows your customers to use their own domains with SSL on your multisite network. It is the recommended approach for domain-mapped multisite installations that use Cloudflare, because Cloudflare manages the SSL certificate issuance and renewal for each custom domain automatically.
+
+### How it differs from the standard Cloudflare integration
+
+| | Standard integration | Cloudflare Custom Hostnames |
+|---|---|---|
+| **Purpose** | Auto-creates DNS records for subdomains | Enables custom (mapped) domains with Cloudflare-managed SSL |
+| **Best for** | Subdomain multisite | Domain-mapped multisite |
+| **SSL** | Handled separately | Managed by Cloudflare automatically |
+
+### Setting up Cloudflare Custom Hostnames
+
+1. In your Cloudflare dashboard, open the zone for your main domain.
+2. Go to **SSL/TLS > Custom Hostnames**.
+3. Add a fallback origin pointing to your server's IP or hostname.
+4. For each customer domain mapped in Ultimate Multisite, add a Custom Hostname entry in Cloudflare. You can automate this step using the Cloudflare API.
+5. Cloudflare issues and renews TLS certificates for each custom hostname automatically once the customer's DNS is pointed at your network.
+
+For full API reference, see [Cloudflare Custom Hostnames documentation](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/).
+
+:::note Terminology update
+As of Ultimate Multisite v2.6.1, this feature is referred to as **Cloudflare Custom Hostnames** in all plugin settings and labels. Earlier versions used the name "Cloudflare for SaaS", which is the underlying Cloudflare product name.
+:::
+
 ## Important Notes
 
-As of Cloudflare's recent updates, wildcard proxying is now available for all customers. This means that the Cloudflare integration is less critical for subdomain multisite installations than it used to be, as you can simply set up a wildcard DNS record in Cloudflare.
+As of Cloudflare's recent updates, wildcard proxying is now available for all customers. This means that the standard Cloudflare DNS integration is less critical for subdomain multisite installations than it used to be, as you can simply set up a wildcard DNS record in Cloudflare.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Documents the three user-facing changes from Ultimate Multisite v2.6.1 (released 2026-04-15).

### Checkout form templates (`docs/user-guide/configuration/checkout-forms.md`)

- Notes that the **single-step** and **multi-step** form templates now include a **Template Selection** field by default.
- Adds a dedicated **Template Selection Field** section explaining how to add it manually, how it works, and how to remove it if site templates are not offered.

### BerlinDB `increment_item()` (`docs/developer/code-examples/index.md`)

- Documents the new atomic counter method added to the BerlinDB `Query` class.
- Includes method signature, basic usage (increment / decrement), a practical membership API-quota example, and an explanation of why it is safer than a read-modify-write pattern.

### Cloudflare Custom Hostnames (`docs/user-guide/host-integrations/cloudflare.md`)

- Adds a **Cloudflare Custom Hostnames** section (the feature was previously labelled "Cloudflare for SaaS" in plugin UI; renamed in v2.6.1).
- Includes a comparison table (standard DNS integration vs Custom Hostnames), setup steps, and a terminology note explaining the rename.

## Verification

All three source docs in `docs/` were modified. The i18n translations in `i18n/` are regenerated by the `translate.yml` workflow on demand — no manual translation edits are needed here.

Resolves #19