### PR TITLE
GH#20: docs: document Network Activate button in setup wizard for v2.6.1

### DIFF
--- a/docs/user-guide/getting-started/installing-ultimate-multisite.md
+++ b/docs/user-guide/getting-started/installing-ultimate-multisite.md
@@ -45,6 +45,12 @@ This step checks your system information and WordPress installation to make sure
 
 ![Pre-install checks showing system requirements](/img/installation/wizard-pre-install-checks.png)
 
+:::note Network Activate button (v2.6.1+)
+If Ultimate Multisite was installed but **not yet network-activated** — for example, if you clicked **Activate** (single-site) instead of **Network Activate** from the network plugins screen — the Pre-install Checks step will detect this and display a **Network Activate** button.
+
+Clicking **Network Activate** activates the plugin across your entire multisite network automatically. Once activated, the wizard continues normally to the installation step. You do not need to leave the wizard to fix the activation state.
+:::
+
 ### Installation
 
 The installer will create the necessary database tables and install the `sunrise.php` file that Ultimate Multisite needs to function. Click **Install** to proceed.


### PR DESCRIPTION
## Summary

Documents the new Network Activate button added in v2.6.1 that appears in the Pre-install Checks step of the Setup Wizard when the plugin is installed but not yet network-activated. Adds a callout note explaining the detection and the changed flow so users do not need to leave the wizard to fix the activation state. The other four items from issue #20 (Template Selection field, increment_item() method, Cloudflare Custom Hostnames rename, Composer package rename) were already addressed in PR #28; no devstone/ references were found in the documentation.

## Files Changed

docs/user-guide/getting-started/installing-ultimate-multisite.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Manually verified the markdown renders correctly with the ::: note admonition. The file builds as valid Docusaurus MDX.

Resolves #20


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 5m and 11,070 tokens on this as a headless worker.