### PR TITLE
GH#18: docs: add Composer/Bedrock installation section with updated package name

### DIFF
--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -21,6 +21,30 @@ This guide provides developers with everything needed to integrate with, extend,
 - PHP 7.4 or higher
 - Ultimate Multisite plugin activated
 
+## Composer / Bedrock Installation
+
+Ultimate Multisite is available on [Packagist](https://packagist.org/packages/ultimate-multisite/ultimate-multisite) as `ultimate-multisite/ultimate-multisite`. This is the recommended installation method for [Bedrock](https://roots.io/bedrock/)-based WordPress setups and other Composer-managed environments.
+
+```bash
+composer require ultimate-multisite/ultimate-multisite
+```
+
+:::note Renamed package (v2.6.1+)
+The Composer package was renamed from `devstone/ultimate-multisite` to `ultimate-multisite/ultimate-multisite` in v2.6.1. If your `composer.json` references the old vendor name, update the require entry and run `composer update`.
+:::
+
+After installation, network-activate the plugin from the Network Admin:
+
+```bash
+wp plugin activate ultimate-multisite --network
+```
+
+Or, if you are loading the plugin as a must-use plugin via Bedrock's autoloader, use the `wp_ultimo_skip_network_active_check` filter to bypass the activation guard:
+
+```php
+add_filter( 'wp_ultimo_skip_network_active_check', '__return_true' );
+```
+
 ## Quick Start
 
 ### Use the REST API


### PR DESCRIPTION
## Summary

Added Composer/Bedrock installation section to docs/developer/index.md documenting the new package name 'ultimate-multisite/ultimate-multisite' (renamed from 'devstone/ultimate-multisite' in v2.6.1), with activation instructions and the skip_network_active_check filter for mu-plugin setups.

## Files Changed

docs/developer/index.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** All other v2.6.1 doc updates (template selection field, Network Activate button, WordPress.org install method, Cloudflare Custom Hostnames rename, BerlinDB increment_item) were already present on the branch from prior commits.

Resolves #18


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 7,242 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Composer and Bedrock installation guides with step-by-step instructions
  * Documented package rename in v2.6.1 and required updates
  * Included network activation procedures for standard and Bedrock-based deployments
  * Added reference for alternative activation method using filter configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->