### PR TITLE
docs: document Gratis AI Agent v1.9.0 features

### DIFF
--- a/docs/addons/gratis-ai-agent/abilities.md
+++ b/docs/addons/gratis-ai-agent/abilities.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 Abilities are the atomic actions that Gratis AI Agent can invoke on your WordPress installation. Each ability is a registered PHP class that exposes a JSON schema — the agent reads this schema at runtime to understand what parameters are required and what the ability returns.
 
-This page documents all abilities shipping with Gratis AI Agent v1.4.0.
+This page documents all abilities shipping with Gratis AI Agent v1.9.0.
 
 ---
 
@@ -493,6 +493,293 @@ Lists WordPress options matching a pattern.
     { "option_name": "gratis_ai_agent_version", "autoload": "yes" }
   ],
   "total": 1
+}
+```
+
+---
+
+## Content Management
+
+Content Management abilities create and edit WordPress posts and pages. Post IDs are returned so subsequent steps in multi-ability plans can reference the created content.
+
+### `create_post`
+
+Creates a new WordPress post, page, or custom post type entry.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | Yes | Post title |
+| `content` | string | No | Post body — accepts plain text, HTML, or serialised block markup |
+| `status` | string | No | `draft`, `publish`, `pending`, `private`. Default `draft` |
+| `post_type` | string | No | Post type slug, e.g. `post`, `page`, or any registered CPT. Default `post` |
+| `excerpt` | string | No | Short summary shown in archives and search results |
+| `categories` | array | No | Array of category names or IDs to assign |
+| `tags` | array | No | Array of tag names or IDs to assign |
+| `author` | integer | No | WordPress user ID to set as the post author. Defaults to the current user |
+| `date` | string | No | Publish date in ISO 8601 format, e.g. `2026-05-01T09:00:00` |
+| `page_template` | string | No | Template file to assign to this post or page, e.g. `page-full-width.php`. Only meaningful when `post_type` is `page` or a CPT that supports page templates. |
+
+**Example**
+
+```json
+{
+  "title": "Welcome to Our New Site",
+  "content": "<!-- wp:paragraph --><p>Hello world!</p><!-- /wp:paragraph -->",
+  "status": "publish",
+  "post_type": "page",
+  "page_template": "page-full-width.php"
+}
+```
+
+**Returns** `{ "success": true, "post_id": 42, "permalink": "https://example.com/welcome/" }`
+
+---
+
+### `update_post`
+
+Updates an existing WordPress post or page.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post_id` | integer | Yes | ID of the post to update |
+| `title` | string | No | New post title |
+| `content` | string | No | New post body |
+| `status` | string | No | New status: `draft`, `publish`, `pending`, `private` |
+| `excerpt` | string | No | New excerpt |
+| `categories` | array | No | Replace the full category list with this array of names or IDs |
+| `tags` | array | No | Replace the full tag list with this array of names or IDs |
+| `page_template` | string | No | New template file to assign to this post or page, e.g. `page-full-width.php`. Pass an empty string to remove the template assignment and revert to the theme default. |
+
+**Example** — change template after creation
+
+```json
+{
+  "post_id": 42,
+  "page_template": "page-full-width.php"
+}
+```
+
+**Returns** `{ "success": true, "post_id": 42 }`
+
+---
+
+### `batch_create_posts`
+
+Creates multiple posts in a single ability call, reducing round-trips during site builds or bulk content import. Posts are created in sequence; if one fails the others continue and the failure is reported in the results array.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `posts` | array | Yes | Array of post objects, each accepting the same parameters as `create_post` |
+| `stop_on_error` | boolean | No | If `true`, stop processing after the first failure. Default `false` |
+
+**Example**
+
+```json
+{
+  "posts": [
+    {
+      "title": "About Us",
+      "post_type": "page",
+      "status": "publish",
+      "page_template": "page-full-width.php"
+    },
+    {
+      "title": "Services",
+      "post_type": "page",
+      "status": "publish"
+    },
+    {
+      "title": "Contact",
+      "post_type": "page",
+      "status": "publish"
+    }
+  ]
+}
+```
+
+**Returns**
+
+```json
+{
+  "created": 3,
+  "failed": 0,
+  "results": [
+    { "success": true, "post_id": 42, "title": "About Us" },
+    { "success": true, "post_id": 43, "title": "Services" },
+    { "success": true, "post_id": 44, "title": "Contact" }
+  ]
+}
+```
+
+---
+
+### `set_featured_image`
+
+Assigns a featured image (post thumbnail) to an existing post or page. Accepts an existing Media Library attachment ID or a remote image URL; when a URL is supplied, the image is downloaded and imported automatically.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post_id` | integer | Yes | ID of the post or page to update |
+| `attachment_id` | integer | No | ID of an existing Media Library attachment |
+| `url` | string | No | Remote image URL to import and set as the featured image |
+| `alt_text` | string | No | Alt text to apply to the attachment if it is imported from a URL |
+
+One of `attachment_id` or `url` must be provided.
+
+**Returns** `{ "success": true, "post_id": 42, "attachment_id": 17 }`
+
+---
+
+### `create_contact_form`
+
+Creates a contact form using the active form plugin (Contact Form 7, WPForms, Fluent Forms, or Gravity Forms, depending on which is installed). Returns a shortcode that can be embedded in any post or page.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | Yes | Form name shown in the form plugin admin |
+| `fields` | array | Yes | Ordered list of form fields (see Field object below) |
+| `recipient` | string | No | Email address to receive submissions. Defaults to the WordPress admin email |
+| `subject` | string | No | Email subject line. Supports `[your-name]` and `[your-subject]` placeholders when using Contact Form 7 |
+| `confirmation_message` | string | No | Message displayed after a successful submission. Default: `"Thank you for your message. We'll be in touch soon."` |
+
+**Field object**
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Internal field name / machine key |
+| `label` | string | Yes | Human-readable label shown on the form |
+| `type` | string | Yes | `text`, `email`, `tel`, `textarea`, `select`, `checkbox`, `radio`, `file`, `date` |
+| `required` | boolean | No | Whether the field must be filled before submission. Default `false` |
+| `options` | array | No | Options for `select`, `checkbox`, and `radio` fields |
+| `placeholder` | string | No | Placeholder text for text-type inputs |
+
+**Example**
+
+```json
+{
+  "title": "Restaurant Booking Enquiry",
+  "fields": [
+    { "name": "your-name",    "label": "Name",             "type": "text",     "required": true },
+    { "name": "your-email",   "label": "Email",            "type": "email",    "required": true },
+    { "name": "party-size",   "label": "Party size",       "type": "select",   "options": ["1–2", "3–5", "6–10", "10+"] },
+    { "name": "your-message", "label": "Special requests", "type": "textarea", "required": false }
+  ],
+  "recipient": "bookings@example.com",
+  "subject": "New booking enquiry from [your-name]"
+}
+```
+
+**Returns**
+
+```json
+{
+  "success": true,
+  "form_id": 3,
+  "shortcode": "[contact-form-7 id=\"3\" title=\"Restaurant Booking Enquiry\"]"
+}
+```
+
+---
+
+## Visual Review
+
+Visual Review abilities let the agent capture screenshots of live pages and analyse them, enabling autonomous design review, before/after comparisons, and visual regression checks without requiring any browser extension.
+
+### `capture_screenshot`
+
+Captures a screenshot of a WordPress page at a given URL using a server-side headless browser. The image is saved to the Media Library and a CDN URL is returned.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | Yes | Full URL of the page to screenshot, e.g. `https://example.com/about/` |
+| `width` | integer | No | Viewport width in pixels. Default `1280` |
+| `height` | integer | No | Viewport height in pixels. Default `800` |
+| `full_page` | boolean | No | Capture the full scrollable page instead of just the viewport. Default `false` |
+| `delay_ms` | integer | No | Milliseconds to wait after page load before capturing, useful for animated content. Default `500` |
+| `label` | string | No | Human-readable label stored with the attachment in the Media Library |
+
+**Returns**
+
+```json
+{
+  "success": true,
+  "attachment_id": 88,
+  "url": "https://example.com/wp-content/uploads/2026/04/screenshot-about.png",
+  "width": 1280,
+  "height": 800
+}
+```
+
+---
+
+### `compare_screenshots`
+
+Takes two screenshots and returns a visual diff score plus a diff image highlighting changed regions. Useful for confirming that a design change produced the expected result or for detecting unintended regressions.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `before_url` | string | Yes | URL of the page to capture as the "before" state |
+| `after_url` | string | Yes | URL of the page to capture as the "after" state. May be the same URL if comparing across time |
+| `width` | integer | No | Viewport width for both captures. Default `1280` |
+| `threshold` | float | No | Pixel-difference threshold (0.0–1.0). Pixels within this tolerance are considered unchanged. Default `0.1` |
+
+**Returns**
+
+```json
+{
+  "success": true,
+  "diff_score": 0.04,
+  "changed_pixels": 2340,
+  "total_pixels": 1024000,
+  "diff_attachment_id": 91,
+  "diff_url": "https://example.com/wp-content/uploads/2026/04/diff-about.png"
+}
+```
+
+A `diff_score` of `0.0` means no visible change; `1.0` means every pixel changed.
+
+---
+
+### `review_page_design`
+
+Captures a screenshot of a page and sends it to the language model for visual analysis. Returns a structured assessment covering layout, typography, colour usage, and accessibility concerns.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | string | Yes | Full URL of the page to review |
+| `focus` | string | No | Comma-separated list of review areas to emphasise: `layout`, `typography`, `colour`, `accessibility`, `mobile`. Default: all areas |
+| `width` | integer | No | Viewport width. Default `1280` |
+
+**Returns**
+
+```json
+{
+  "success": true,
+  "screenshot_url": "https://example.com/wp-content/uploads/2026/04/review-about.png",
+  "assessment": {
+    "overall": "The page structure is clean and readable. Two accessibility issues detected.",
+    "layout": "Good visual hierarchy. Hero section is prominent.",
+    "typography": "Body text is 15px — consider increasing to 16px for readability.",
+    "colour": "Contrast ratio on the CTA button (#fff on #4a90e2) is 3.1:1 — below the WCAG AA threshold of 4.5:1.",
+    "accessibility": ["Low contrast on CTA button", "Missing alt text on hero image"],
+    "suggestions": ["Darken the CTA button to #1a5cb0 to pass WCAG AA", "Add descriptive alt text to the hero image"]
+  }
 }
 ```
 

--- a/docs/addons/gratis-ai-agent/changelog.md
+++ b/docs/addons/gratis-ai-agent/changelog.md
@@ -5,6 +5,45 @@ sidebar_position: 5
 
 # Changelog
 
+## 1.9.0 — Released on 2026-04-28
+
+### New
+
+- **`create_contact_form` ability** — creates a contact form using the active form plugin (Contact Form 7, WPForms, Fluent Forms, or Gravity Forms) and returns a shortcode ready to embed in any post or page.
+- **`set_featured_image` ability** — assigns a featured image to a post or page from an existing Media Library attachment ID or a remote URL; automatically imports the image when a URL is provided.
+- **`batch_create_posts` ability** — creates multiple posts in a single ability call. Supports the same parameters as `create_post`, reports per-post success/failure, and has an optional `stop_on_error` mode.
+- **`page_template` parameter** — added to `create_post` and `update_post`. Assigns a PHP page template file (e.g. `page-full-width.php`) at create or update time. Pass an empty string to `update_post` to revert to the theme default.
+- **Client-side screenshot abilities** — `capture_screenshot`, `compare_screenshots`, and `review_page_design`. Capture full or viewport screenshots of live pages via a server-side headless browser, diff two screenshots, and get an AI-generated design review covering layout, typography, colour, and accessibility.
+- **Five built-in agents** — Content Writer, Site Builder, Design Studio, Plugin Manager, and Support Assistant. Each agent has a dedicated set of tools, a tailored system prompt, and starter suggestions. Switchable via the new **Agent Picker** in the chat header. See [Built-in Agents](../../user-guide/configuration/built-in-agents).
+- **Feature flags** — new **Settings → Feature Flags** tab with access-control toggles (restrict to administrators, restrict to network admins, subscriber access, disable for non-members) and branding options (hide footer attribution, custom agent name, hide agent picker, use site icon as chat avatar). See [Gratis AI Agent Settings](../../user-guide/administration/gratis-ai-agent-settings).
+- **Restore last session** — the chat panel now reloads the most recent conversation automatically on page load and on widget open, so context is never lost across page navigations.
+- **Plugin action links** — quick links to Settings and the Abilities Registry now appear on the WordPress **Plugins → Installed Plugins** screen below the plugin description.
+
+### Improved
+
+- **Image source retry** — the agent now retries all configured free image sources before falling back to an AI-generated image on download failure.
+- **Model info panel** — always visible in the chat header; no longer hidden after the first message.
+- **Auto-scroll behaviour** — auto-scroll pauses when the user scrolls up to read; a floating **Scroll to bottom** button appears and dismisses automatically when the user reaches the latest message.
+- **Agent Picker UI** — redesigned as a form-table overlay with per-agent icons, making it easier to identify and switch agents at a glance.
+- **Lazy-loaded JS chunks** — the chat widget's initial JavaScript bundle is now split into lazy-loaded chunks, reducing the initial bundle sizes by 75–90%.
+- **Chat widget redesign** — unified AI icon replaces the previous custom avatar; consistent with the built-in agent system.
+- **URL linkification** — URLs appearing in system messages and error message bubbles are now rendered as clickable links.
+
+### Fixed
+
+- **Ability discoverability** — corrected descriptions, system prompt references, and namespace alignment so all abilities appear in the agent's tool list reliably.
+- **Providers cache** — providers are now cached site-wide via a version counter, preventing stale-provider issues on multisite networks.
+- **`ability_invalid_output`** — resolved across 12 ability handlers; all return properly structured JSON responses.
+- **`pending_client_tool_calls` pipeline** — wired end-to-end so client-side tool calls complete correctly and return results to the model.
+- **History drawer** — non-revertable changes are excluded from the revert list; the **View full history** link now works correctly.
+- **Changes/revert system** — five separate bugs fixed and unified under the new admin interface.
+- **Save Settings toast** — snackbar notification now appears reliably after clicking **Save Settings**.
+- **Trash context menu** — added **Delete Permanently** option so items can be hard-deleted without leaving the trash view.
+- **Edit & resend** — clicking the edit icon now enters edit mode only for the clicked message, not all messages in the thread.
+- **Chat layout height** — the chat panel adapts its height when plugin-injected content (admin notices, banners) appears above the page, preventing the input area from being pushed off-screen.
+
+---
+
 ## 1.4.0 — Released on 2026-04-09
 
 ### New

--- a/docs/addons/gratis-ai-agent/index.mdx
+++ b/docs/addons/gratis-ai-agent/index.mdx
@@ -9,11 +9,15 @@ import AddonBanner from '@site/src/components/AddonBanner';
 
 # Gratis AI Agent
 
-Gratis AI Agent is an autonomous WordPress AI assistant that can plan, build, and manage complete WordPress sites through natural language instructions. It exposes a structured set of **abilities** — discrete, testable actions the agent can invoke — covering everything from content management to design system customisation. Version 1.4.0 significantly expands the ability surface and introduces Site Builder Orchestration v2 for end-to-end website creation workflows.
+Gratis AI Agent is an autonomous WordPress AI assistant that can plan, build, and manage complete WordPress sites through natural language instructions. It exposes a structured set of **abilities** — discrete, testable actions the agent can invoke — covering everything from content management to design system customisation. Version 1.9.0 adds content creation abilities, visual page review via client-side screenshots, five built-in agent profiles, and feature flags for access control and branding.
 
 ## Key Features
 
 - **Abilities system** — a modular, extensible catalogue of actions the agent can invoke on your WordPress installation
+- **Content Management** — create posts and pages (including assigning page templates), batch-create multiple posts in one call, set featured images, and build contact forms
+- **Visual Review** — capture screenshots of live pages, diff before/after states, and get an AI-generated design review covering layout, typography, colour, and accessibility
+- **Five built-in agents** — Content Writer, Site Builder, Design Studio, Plugin Manager, and Support Assistant; switchable via the Agent Picker in the chat header
+- **Feature flags** — access-control and branding toggles in Settings → Feature Flags for role restrictions, white-label naming, and widget customisation
 - **Custom Post Type management** — register, list, and delete custom post types with persistence across restarts
 - **Custom Taxonomy management** — register, list, and delete custom taxonomies with persistence
 - **Design System abilities** — inject custom CSS, manage curated block patterns, set the site logo, and apply theme.json presets
@@ -62,6 +66,8 @@ Abilities are the atomic actions the agent can perform. Each ability is a regist
 
 | Area | Abilities |
 |---|---|
+| **Content Management** | `create_post`, `update_post`, `batch_create_posts`, `set_featured_image`, `create_contact_form` |
+| **Visual Review** | `capture_screenshot`, `compare_screenshots`, `review_page_design` |
 | **Custom Post Types** | `register_post_type`, `list_post_types`, `delete_post_type` |
 | **Custom Taxonomies** | `register_taxonomy`, `list_taxonomies`, `delete_taxonomy` |
 | **Design System** | `inject_custom_css`, `add_block_pattern`, `list_block_patterns`, `set_site_logo`, `apply_theme_json_preset` |

--- a/docs/user-guide/administration/gratis-ai-agent-settings.md
+++ b/docs/user-guide/administration/gratis-ai-agent-settings.md
@@ -72,3 +72,34 @@ Also on the **Advanced** tab, the **Brave Search API Key** field enables the [In
 The field label includes a clickable link to the Brave Search API sign-up page. Leave blank to disable internet search.
 
 See [Internet Search](../configuration/internet-search) for end-user documentation on this feature.
+
+## Feature Flags
+
+Also introduced in v1.9.0, the **Settings → Feature Flags** tab provides toggle switches for optional functionality. Each flag is either enabled or disabled network-wide; there is no per-site override at this time.
+
+### Accessing Feature Flags
+
+1. In the WordPress admin, go to **Gratis AI Agent → Settings**.
+2. Click the **Feature Flags** tab.
+
+### Access Control Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| **Restrict to Administrators** | Off | When enabled, only users with the `administrator` role can open the AI Agent chat panel. All other roles see a "Contact your administrator" message instead. |
+| **Restrict to Network Admins** | Off | When enabled on a multisite network, only Super Admins can use the agent. Individual site admins are blocked. Takes precedence over "Restrict to Administrators" if both are enabled. |
+| **Allow Subscriber Access** | Off | When enabled, users with the `subscriber` role can use the chat interface but are limited to read-only abilities (no post creation or settings changes). |
+| **Disable for Non-Members** | Off | Integrates with Ultimate Multisite membership status. When enabled, chat is hidden for sites that do not have an active membership. |
+
+### Branding Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| **Hide "Powered by Gratis AI Agent" Footer** | Off | Removes the branding attribution line shown at the bottom of the chat widget. Recommended for white-label deployments. |
+| **Custom Agent Name** | *(blank)* | Replaces the default "Gratis AI Agent" label in the chat header and admin menu with your own product name. Leave blank to use the default. |
+| **Hide Agent Picker** | Off | When enabled, users cannot switch between the five built-in agents. The current agent is fixed to whatever is configured as the default in Settings → General. |
+| **Use Site Icon as Chat Avatar** | Off | Replaces the default AI icon in the chat widget header with the WordPress site icon (set under Appearance → Customize → Site Identity). |
+
+### Applying Changes
+
+Click **Save Settings** after toggling any flag. Changes take effect immediately — no cache flush or plugin reactivation is required.

--- a/docs/user-guide/configuration/built-in-agents.md
+++ b/docs/user-guide/configuration/built-in-agents.md
@@ -1,0 +1,166 @@
+---
+title: "Built-in Agents"
+sidebar_position: 12
+---
+
+# Built-in Agents
+
+Gratis AI Agent v1.9.0 ships five built-in agents, each pre-configured with a focused set of tools, a tailored system prompt, and starter suggestions matched to common tasks in that area. Switching between agents changes what the assistant can do and how it responds — without any configuration on your part.
+
+## What Is an Agent?
+
+Each agent is a named configuration profile that combines:
+
+- **Tools** — the abilities the agent is allowed to invoke (e.g. a Content Writer has access to post-creation abilities; a Design Studio has access to CSS and theme.json abilities)
+- **System prompt** — instructions that set the agent's tone, priorities, and constraints
+- **Suggestions** — pre-written prompts shown in the chat interface to help you get started quickly
+
+## Accessing the Agent Picker
+
+1. Open the **Gratis AI Agent** panel in the WordPress admin sidebar.
+2. Click the **agent icon** in the top-left of the chat header (the icon changes to reflect the active agent).
+3. The **Agent Picker** opens as a form-table overlay. Each agent is listed with its icon, name, and a one-line description.
+4. Click an agent row to activate it. The chat header updates immediately.
+
+You can also switch agents mid-conversation — the new agent's system prompt takes effect from the next message.
+
+## The Five Built-in Agents
+
+### Content Writer
+
+**Focus:** Creating and editing posts, pages, and contact forms.
+
+**Available tools:** `create_post`, `update_post`, `batch_create_posts`, `set_featured_image`, `create_contact_form`, `get_option`, `list_post_types`
+
+**What it does well:**
+- Drafting and publishing blog posts from a brief or outline
+- Creating batches of landing pages for a new site
+- Building contact and enquiry forms
+- Setting featured images on posts from a URL or search
+
+**Starter suggestions:**
+- *Write a 500-word blog post about the benefits of WordPress multisite.*
+- *Create an About, Services, and Contact page and publish them.*
+- *Add a booking enquiry form to the Contact page.*
+
+---
+
+### Site Builder
+
+**Focus:** End-to-end website creation from a single prompt.
+
+**Available tools:** `create_site_plan`, `execute_site_plan`, `get_plan_progress`, `handle_plan_error`, `create_post`, `batch_create_posts`, `register_post_type`, `create_menu`, `add_menu_item`, `inject_custom_css`, `apply_theme_json_preset`, `install_ability`, `recommend_plugin`
+
+**What it does well:**
+- Generating a multi-phase site build plan for a described business type
+- Executing each phase autonomously — structure, content, navigation, design
+- Recovering from errors mid-plan without requiring manual intervention
+- Installing recommended plugins as part of the build
+
+**Starter suggestions:**
+- *Build a photography portfolio site with a gallery post type, a booking page, and a contact form.*
+- *Create a restaurant website with an online menu, opening hours, and a table-booking enquiry form.*
+- *Set up a freelance consulting site with service pages, a portfolio section, and a blog.*
+
+---
+
+### Design Studio
+
+**Focus:** Visual customisation — colours, typography, CSS, and block patterns.
+
+**Available tools:** `inject_custom_css`, `apply_theme_json_preset`, `get_global_styles`, `set_global_styles`, `reset_global_styles`, `add_block_pattern`, `list_block_patterns`, `set_site_logo`, `capture_screenshot`, `review_page_design`
+
+**What it does well:**
+- Applying named theme presets (minimal-dark, warm-editorial, corporate-blue, vibrant-startup, classic-blog)
+- Fine-tuning global typography and colour palettes via theme.json
+- Injecting custom CSS for brand-specific overrides
+- Taking a screenshot of a page and reviewing it for design issues
+
+**Starter suggestions:**
+- *Apply the warm-editorial preset and then set the primary colour to #2d6a4f.*
+- *Take a screenshot of the homepage and tell me what you'd improve.*
+- *Create a reusable hero block pattern with a full-width background image and centred heading.*
+
+---
+
+### Plugin Manager
+
+**Focus:** Discovering, installing, and managing WordPress plugins.
+
+**Available tools:** `list_available_abilities`, `install_ability`, `recommend_plugin`, `get_option`, `set_option`
+
+**What it does well:**
+- Recommending the best plugin for a described use case
+- Installing ability packs from the registry
+- Browsing the available ability catalogue by category
+
+**Starter suggestions:**
+- *What's the best plugin for a membership directory?*
+- *Install the WooCommerce abilities pack.*
+- *Show me all available ecommerce ability packs.*
+
+---
+
+### Support Assistant
+
+**Focus:** Answering questions about site content, settings, and WordPress configuration.
+
+**Available tools:** `get_option`, `list_options`, `list_post_types`, `list_taxonomies`, `list_menus`, `list_available_abilities`
+
+**What it does well:**
+- Looking up current site settings and options
+- Explaining what post types, taxonomies, and menus are configured on the site
+- Answering "what does this setting do?" questions by reading live values
+- Serving as a read-only diagnostic layer before making changes
+
+**Starter suggestions:**
+- *What plugins and settings are currently active on this site?*
+- *List all the custom post types registered on this site.*
+- *What navigation menus exist and where are they assigned?*
+
+---
+
+## Customising Agents
+
+Each built-in agent can be extended or replaced through the `gratis_ai_agent_agents` filter.
+
+### Adding a custom system prompt to an existing agent
+
+```php
+add_filter( 'gratis_ai_agent_agents', function ( array $agents ): array {
+    if ( isset( $agents['content-writer'] ) ) {
+        $agents['content-writer']['system_prompt'] .= "\n\nAlways write in British English and use the Oxford comma.";
+    }
+    return $agents;
+} );
+```
+
+### Registering a new agent
+
+```php
+add_filter( 'gratis_ai_agent_agents', function ( array $agents ): array {
+    $agents['seo-specialist'] = [
+        'name'          => 'SEO Specialist',
+        'description'   => 'Optimises posts and pages for search engines.',
+        'icon'          => 'dashicons-search',
+        'tools'         => [ 'get_option', 'set_option', 'create_post', 'update_post', 'list_post_types' ],
+        'system_prompt' => 'You are an SEO specialist. Focus on keyword optimisation, meta descriptions, and structured data.',
+        'suggestions'   => [
+            'Review the homepage title and meta description.',
+            'Suggest title tag improvements for the five most recent posts.',
+        ],
+    ];
+    return $agents;
+} );
+```
+
+The new agent appears in the Agent Picker immediately after the filter runs.
+
+### Removing a built-in agent
+
+```php
+add_filter( 'gratis_ai_agent_agents', function ( array $agents ): array {
+    unset( $agents['plugin-manager'] );
+    return $agents;
+} );
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,6 +45,7 @@ const sidebars = {
         'user-guide/configuration/the-registration-flow',
         'user-guide/configuration/feedback-and-issue-reporting',
         'user-guide/configuration/internet-search',
+        'user-guide/configuration/built-in-agents',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Documents all required updates for the AI Agent for WP / Gratis AI Agent v1.9.0 release (issue #35).

Resolves #35

## Changes

### `docs/addons/gratis-ai-agent/abilities.md`
- Version reference updated from 1.4.0 → 1.9.0
- **New section: Content Management** — documents `create_post` and `update_post` (with new `page_template` parameter), `batch_create_posts`, `set_featured_image`, and `create_contact_form` abilities with full parameter tables and examples
- **New section: Visual Review** — documents `capture_screenshot`, `compare_screenshots`, and `review_page_design` client-side screenshot abilities

### `docs/user-guide/configuration/built-in-agents.md` *(new file)*
- Documents the five built-in agents: Content Writer, Site Builder, Design Studio, Plugin Manager, Support Assistant
- Covers available tools per agent, what each does well, and starter suggestions
- Includes PHP filter examples for customising system prompts, registering new agents, and removing built-in ones

### `docs/user-guide/administration/gratis-ai-agent-settings.md`
- New **Feature Flags** section covering the Settings → Feature Flags tab
- Documents four access-control flags (Restrict to Administrators, Restrict to Network Admins, Allow Subscriber Access, Disable for Non-Members)
- Documents four branding flags (Hide footer, Custom agent name, Hide agent picker, Use site icon as chat avatar)

### `docs/addons/gratis-ai-agent/changelog.md`
- Full v1.9.0 release entry with New / Improved / Fixed sections

### `docs/addons/gratis-ai-agent/index.mdx`
- Intro paragraph updated to reference v1.9.0 highlights
- Abilities overview table updated to include Content Management and Visual Review rows

### `sidebars.js`
- `built-in-agents` added to the Configuration sidebar section

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 6m and 20,527 tokens on this as a headless worker.
