### PR TITLE
GH#38: document Ultimate Multisite 2.8.0 updates

### DIFF
--- a/docs/developer/integration-guide/addon-sunrise-loader.md
+++ b/docs/developer/integration-guide/addon-sunrise-loader.md
@@ -1,0 +1,78 @@
+---
+title: "Addon Sunrise File Loader"
+sidebar_position: 5
+---
+
+# Addon Sunrise File Loader
+
+Ultimate Multisite 2.8.0 adds a sunrise extension loader for add-ons and custom MU-plugin integrations that need to run during WordPress sunrise bootstrapping without editing the generated `wp-content/sunrise.php` file.
+
+## When to use it
+
+Use a sunrise extension when your integration must run before regular plugins are loaded, such as custom domain routing, host-specific request handling, or early network bootstrap adjustments.
+
+For normal integrations, prefer regular WordPress plugins, MU-plugins, and the documented Ultimate Multisite hooks. Sunrise code runs very early and should stay small, defensive, and dependency-free.
+
+## File naming convention
+
+Create a PHP file named `sunrise.php` in an addon directory whose name starts with `ultimate-multisite-`:
+
+```text
+wp-content/plugins/ultimate-multisite-example-addon/sunrise.php
+```
+
+The loader scans the plugins directory for this pattern:
+
+```text
+wp-content/plugins/ultimate-multisite-*/sunrise.php
+```
+
+Matching files are loaded in alphabetical order by addon path.
+
+## Where to place the file
+
+Place the file in the root directory of the addon that owns the sunrise behaviour:
+
+```text
+wp-content/
+└── plugins/
+    └── ultimate-multisite-example-addon/
+        ├── ultimate-multisite-example-addon.php
+        └── sunrise.php
+```
+
+The scan is resolved relative to `WP_CONTENT_DIR`, not the current value of `WP_PLUGIN_DIR`. This keeps discovery stable when multi-tenancy or other early bootstrap code changes plugin directory constants during sunrise.
+
+Do not edit the generated `wp-content/sunrise.php` file directly. The loader lets custom code extend sunrise behaviour without forking the core sunrise file that Ultimate Multisite installs and updates.
+
+## Hooks and filters available
+
+Addon sunrise files run after Ultimate Multisite domain mapping has loaded and before WordPress fires `ms_loaded`. At this point a sunrise file can:
+
+- read or override `$current_site` and `$current_blog`;
+- access `$wpdb` after database configuration has loaded;
+- define sunrise-time constants such as `BLOG_ID_CURRENT_SITE` when needed;
+- read Ultimate Multisite sunrise helper state, including routing state used by multi-tenancy integrations.
+
+Ultimate Multisite fires `wu_sunrise_loaded` after its sunrise loader finishes. Use that action for code that should run after sunrise bootstrap is complete but still belongs to the sunrise lifecycle.
+
+Only call functions that are already loaded in the sunrise phase. Avoid database-heavy work, template rendering, HTTP requests, and code that assumes normal plugin load order has completed.
+
+## Minimal example
+
+```php
+<?php
+/**
+ * Sunrise extension for a custom host integration.
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (isset($current_blog) && $current_blog instanceof stdClass) {
+    // Adjust early routing or constants before ms_loaded.
+}
+```
+
+After deploying the file, load a mapped domain and an unmapped main-site URL to confirm both paths still bootstrap correctly.

--- a/docs/user-guide/administration/managing-memberships.md
+++ b/docs/user-guide/administration/managing-memberships.md
@@ -13,6 +13,8 @@ To access this page, go to the **Memberships** tab in the Ultimate Multisite men
 
 On the Memberships page you can see a list of your customers and the products associated with their accounts. You can filter memberships by status: active, pending, on hold, expired, or cancelled.
 
+Free memberships are treated as **lifetime** memberships. They do not receive an expiration date and will not expire automatically. If a free plan should end after a trial or fixed period, use a paid product with a trial, manually cancel the membership, or move the customer to another plan when their access should change.
+
 Click on a membership to access the page where you can edit the membership details — billing info, site or visit limits, and more.
 
 You can also add new memberships associated with users previously registered on your network. Click **Add Membership** and configure the details.

--- a/docs/user-guide/administration/membership-expiration-and-site-blocking.md
+++ b/docs/user-guide/administration/membership-expiration-and-site-blocking.md
@@ -11,6 +11,10 @@ This guide explains how Ultimate Multisite handles membership expiration, trial 
 
 Every membership in Ultimate Multisite has one of the following statuses:
 
+:::note Free memberships are lifetime
+Free memberships do not expire automatically. Ultimate Multisite treats them as lifetime access, so they are not included in expiration checks unless an administrator changes their status or moves the customer to another product.
+:::
+
 | Status | Meaning |
 |---|---|
 | **Pending** | Awaiting first payment or email verification |

--- a/docs/user-guide/administration/settings-reference.md
+++ b/docs/user-guide/administration/settings-reference.md
@@ -1,0 +1,22 @@
+---
+title: "Settings Reference"
+sidebar_position: 11
+---
+
+# Settings Reference
+
+This page tracks settings that affect day-to-day administration and recent behaviour changes in Ultimate Multisite.
+
+## Other Options
+
+The **Other Options** area appears under **Ultimate Multisite > Settings > Login & Registration**.
+
+| Setting | Description |
+|---|---|
+| **Enable Jumper** | Shows the Jumper quick navigation tool in the admin area. Use it to jump directly to Ultimate Multisite screens, network objects, and supported admin destinations. Disable it if you do not want this shortcut visible. |
+
+## Error reporting and telemetry
+
+The previous error-reporting opt-in setting has been removed from the settings page. Anonymous telemetry is disabled and there is no UI toggle to enable it.
+
+If you maintain internal runbooks or screenshots for the settings page, remove references to the old error-reporting opt-in field so administrators do not look for a setting that is no longer present.

--- a/docs/user-guide/configuration/checkout-forms.md
+++ b/docs/user-guide/configuration/checkout-forms.md
@@ -15,6 +15,15 @@ To access this feature, go to the Checkout Forms menu, on the left side-bar.
 
 On this page, you can see all the checkout forms you have.
 
+The list table includes a **Status** column so you can confirm whether each form is currently available to customers:
+
+| Status | Meaning |
+|---|---|
+| **Active** | The form can be used anywhere its shortcode or registration page is published. |
+| **Inactive** | The form is saved but disabled. Customers cannot complete checkout with it until you enable it again. |
+
+Use the status column before editing a public registration flow, especially when you keep draft or seasonal checkout forms alongside your live forms.
+
 If you want to create a new one, just click Add Checkout Form on the top of the page.
 
 You can select one of these three options as your starting point: single step, multi-step or blank. Then, click to Go to the Editor.

--- a/docs/user-guide/configuration/customizing-your-registration-form.md
+++ b/docs/user-guide/configuration/customizing-your-registration-form.md
@@ -33,6 +33,8 @@ Now, lets see other options that are still relevant to the login and registratio
 
   * **Default role:** This is the role that your customers will have on their website after the signup process.
 
+  * **Enable Jumper:** Enables the Jumper shortcut in the admin area. Jumper lets administrators quickly jump to Ultimate Multisite screens, network objects, and other supported destinations without browsing through every menu. Turn it off if you prefer to hide that quick navigation tool from the admin interface.
+
   * **Add users to the main site as well:** Enabling this option will also add the user to the main site of your network after the signup process. If you enable this option, an option to set the **default role** of these users on your website will also appear right below.
 
   * **Enable multiple accounts:** Allow users to have accounts in different sites of your network with the same email address. If this option is off, your customers will not be able to create an account on other websites running on your network with the same email address.

--- a/docs/user-guide/getting-started/release-notes.md
+++ b/docs/user-guide/getting-started/release-notes.md
@@ -1,0 +1,35 @@
+---
+title: "Release Notes"
+sidebar_position: 9
+---
+
+# Release Notes
+
+## Version 2.8.0 — Released on 2026-04-29
+
+- New: Enable Jumper toggle added to Other Options settings UI.
+- New: Status column added to the checkout forms list table.
+- New: Addon sunrise file loader for custom MU-plugin sunrise extensions.
+- Improved: Removed error-reporting opt-in setting from settings page.
+- Fix: Thank-you page site card — image now constrained and links styled correctly.
+- Fix: Screenshot provider switched from thum.io to WordPress.com mShots.
+- Fix: Enable Registration and Default Role now set correct defaults on fresh install.
+- Fix: `get_site_url()` no longer returns empty when domain includes a port.
+- Fix: Clone media files now copied correctly when `copy_media` setting was empty.
+- Fix: Object cache invalidated correctly after network-activate sitemeta write.
+- Fix: Custom domain auto-promoted to primary on DNS verification for 3-part domains.
+- Fix: Pending membership cancelled when expired payment is cleaned up.
+- Fix: Password strength checker rebound after inline login prompt dismissed.
+- Fix: Infinite page reload stopped on thank-you page when site already created.
+- Fix: WP core registration option synced on plugin activation and settings save.
+- Fix: Null expiration guard added in `calculate_expiration` for PHP 8.4 compatibility.
+- Fix: Duplicate signups blocked when customer already has an active membership.
+- Fix: Null check added for `date_expiration` in checkout.
+- Fix: Site provisioning hardened — limitations, membership inference, domain promotion.
+- Fix: Pre-install check status label corrected to NOT Activated when check fails.
+- Fix: Checkout domain used for email verification URLs.
+- Fix: Auto-login after checkout when no password field is present.
+- Fix: Free memberships no longer expire — treated as lifetime.
+- Fix: Email verification gate holds site publish until customer verifies email.
+- Fix: SES v2 API endpoint base path and identity route corrected.
+- Fix: `wu_inline_login_error` hook emitted in pre-submit catch block.

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,6 +13,7 @@ const sidebars = {
         'user-guide/getting-started/installing-ultimate-multisite',
         'user-guide/getting-started/multisite-setup-wizard',
         'user-guide/getting-started/how-to-install-wordpress-multisite',
+        'user-guide/getting-started/release-notes',
       ],
     },
     {
@@ -29,6 +30,7 @@ const sidebars = {
         'user-guide/administration/managing-system-emails',
         'user-guide/administration/plugin-builder-and-sandbox',
         'user-guide/administration/gratis-ai-agent-settings',
+        'user-guide/administration/settings-reference',
       ],
     },
     {
@@ -206,6 +208,7 @@ const sidebars = {
         'developer/integration-guide/custom-gateway',
         'developer/integration-guide/webhooks',
         'developer/integration-guide/plugin-management-abilities',
+        'developer/integration-guide/addon-sunrise-loader',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Documented the v2.8.0 user-facing and developer-facing changes: Jumper setting, checkout form status column, sunrise addon loader, telemetry removal, lifetime free memberships, and release notes.

## Files Changed

docs/developer/integration-guide/addon-sunrise-loader.md,docs/user-guide/administration/managing-memberships.md,docs/user-guide/administration/membership-expiration-and-site-blocking.md,docs/user-guide/administration/settings-reference.md,docs/user-guide/configuration/checkout-forms.md,docs/user-guide/configuration/customizing-your-registration-form.md,docs/user-guide/getting-started/release-notes.md,sidebars.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check passed; npm run clear && npm run build generated English and Spanish output before the full all-locale build exceeded the 240s watchdog-safe timeout; npm run build -- --locale en compiled client and server but Docusaurus 3.9.2/Node 22 ended with ENOENT for build/__server/server.bundle.js.

Resolves #38


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 22m and 92,334 tokens on this as a headless worker.