### PR TITLE
Docs update: single-site export/import

### DIFF
--- a/docs/user-guide/administration/export-import.md
+++ b/docs/user-guide/administration/export-import.md
@@ -1,0 +1,58 @@
+---
+title: "Export & Import"
+sidebar_position: 12
+---
+
+# Export & Import
+
+Ultimate Multisite 2.9.0 adds a single-site **Export & Import** tool under **Tools > Export & Import**. Use it when you need to package one WordPress site as a ZIP file, restore that ZIP, or move a site between compatible Ultimate Multisite and single-site WordPress installations.
+
+## Required permissions
+
+You must sign in as an administrator who can access the WordPress **Tools** menu on the site being exported or imported. On a multisite network, use a network administrator account when exporting or importing subsites from network-level Ultimate Multisite tools.
+
+Export ZIP downloads are served through an authenticated download endpoint, so keep the admin session active until the download finishes and do not share generated download URLs publicly.
+
+## Exporting a site to a ZIP
+
+1. In the WordPress admin for the site you want to copy, go to **Tools > Export & Import**.
+2. Open the export area and choose the site you want to package.
+3. Select the optional content to include, such as uploads, plugins, and themes, when those options are available.
+4. Start the export and wait for the process to finish. Large sites may need to finish in the background before the ZIP is ready.
+5. Download the finished ZIP from the exports list.
+
+Keep the ZIP in a secure location. It can contain site content, settings, media files, and selected code assets.
+
+## What the export includes
+
+An export ZIP can include:
+
+- The selected site's database content and configuration.
+- Uploaded media files when uploads are included.
+- Plugins and themes when those options are selected.
+- Import metadata used by the Export & Import tool to rebuild the site on the target installation.
+
+The exact ZIP size depends on the amount of media, the selected plugins and themes, and the size of the site's database tables.
+
+## Importing a site from a ZIP
+
+1. Go to **Tools > Export & Import** on the destination WordPress site.
+2. Open the import area and upload the ZIP created by the Export & Import tool.
+3. Enter a replacement URL if the site should use a new address, or leave the field blank to keep the original URL.
+4. Choose whether to delete the uploaded ZIP after the import finishes.
+5. Click **Begin Import**.
+6. Monitor the pending import until it finishes. Use **Cancel Import** only if you need to stop the process before completion.
+7. Review the imported site before allowing normal traffic or customer access.
+
+On a single-site WordPress installation, importing a ZIP replaces the current site with the imported site. Create a full backup of the target site before you begin, and avoid starting multiple imports for the same site at the same time.
+
+## Limitations and compatibility notes
+
+- Very large uploads directories or media libraries can produce large ZIP files. Confirm PHP upload limits, execution limits, disk space, memory, and server timeout settings before exporting or importing large sites.
+- Very large media libraries may need to be moved during a low-traffic maintenance window.
+- The target WordPress installation should run compatible WordPress, PHP, Ultimate Multisite, plugin, and theme versions.
+- A single-site import replaces the target site. It is not a merge tool.
+- Multisite-to-single-site and single-site-to-multisite moves are supported only when the target environment can run the exported site's plugins, themes, URLs, and required Ultimate Multisite components.
+- Keep the ZIP private. It may contain database content, uploaded files, and configuration details from the exported site.
+
+For older network-level export workflows, see [Site Export](/user-guide/administration/site-export).

--- a/docs/user-guide/administration/settings-reference.md
+++ b/docs/user-guide/administration/settings-reference.md
@@ -23,4 +23,4 @@ If you maintain internal runbooks or screenshots for the settings page, remove r
 
 ## Import/Export settings
 
-The **Import/Export** settings tab describes which settings it controls and links directly to **Ultimate Multisite > Site Export** for site and network archives. Use the settings tab for import/export configuration, and use the Site Export tool when you need to generate a single-site export or a full Network Export archive.
+The **Import/Export** settings tab describes which settings it controls and links directly to **Ultimate Multisite > Site Export** for site and network archives. Use the settings tab for import/export configuration, use **Tools > Export & Import** for the single-site export/import workflow, and use the Site Export tool when you need a full Network Export archive.

--- a/docs/user-guide/administration/site-export.md
+++ b/docs/user-guide/administration/site-export.md
@@ -29,3 +29,5 @@ To restore a self-booting ZIP on a fresh host:
 4. Review the bundled `readme.txt` for export-specific notes before removing temporary files.
 
 For addon-specific installation and import details, see the [Site Exporter addon documentation](/addons/site-exporter).
+
+For the single-site tool added in Ultimate Multisite 2.9.0, see [Export & Import](/user-guide/administration/export-import).

--- a/docs/user-guide/getting-started/release-notes.md
+++ b/docs/user-guide/getting-started/release-notes.md
@@ -26,6 +26,20 @@ sidebar_position: 9
 - Fix: Filtered SSO path respected across all login flows.
 - Fix: Blank site identity options preserved on save.
 
+## Version 2.9.0 — Released on 2026-04-30
+
+- New: Single-site export and import added under **Tools > Export & Import**.
+- Fix: Export ZIP files now served through an authenticated download endpoint.
+- Fix: SQL injection risk and query issues in pending export/import queries corrected.
+- Fix: Pending site not published when admin manually verifies customer email.
+- Fix: Orphaned pending_site records cleaned up when membership is missing.
+- Fix: Settings nav padding and search anchor navigation corrected.
+- Fix: Pending sites now shown first in the All Sites view.
+- Fix: Screenshot provider (mShots) User-Agent header added to prevent 403 errors.
+- Fix: Import cron schedule circular dependency resolved.
+- Fix: Tour IDs normalised to underscores in user settings keys.
+- Improved: ZipArchive now used instead of Alchemy/Zippy for better compatibility.
+
 ## Version 2.8.0 — Released on 2026-04-29
 
 - New: Enable Jumper toggle added to Other Options settings UI.

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
         'user-guide/administration/managing-payments-and-invoices',
         'user-guide/administration/managing-system-emails',
         'user-guide/administration/site-export',
+        'user-guide/administration/export-import',
         'user-guide/administration/plugin-builder-and-sandbox',
         'user-guide/administration/gratis-ai-agent-settings',
         'user-guide/administration/settings-reference',


### PR DESCRIPTION
## Summary
- Add a new Export & Import administration page for the Ultimate Multisite 2.9.0 single-site ZIP workflow under Tools > Export & Import.
- Cross-link the existing Site Export and settings docs so users can distinguish single-site import/export from network export workflows.
- Add the 2.9.0 release notes entry from the release brief.

## Verification
- `git diff --check`
- `npm run build -- --locale en`
- `npm run build` was attempted for all locales but exceeded the 20 minute tool timeout after successfully building multiple locales; warnings observed were pre-existing translated-content broken links/anchors unrelated to this change.

Resolves #39

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 24m and 65,346 tokens on this as a headless worker.
