### PR TITLE
GH#106: docs: Ultimate Multisite Captcha v1.5.0 — rate limiter and IP trust

### DIFF
--- a/docs/addons/captcha/changelog.md
+++ b/docs/addons/captcha/changelog.md
@@ -5,6 +5,25 @@ sidebar_position: 99
 
 # Captcha Changelog
 
+Version: 1.5.0 - Released on 2026-05-22
+* New: Hard-stop rate limiter — counts every GET and POST on captcha-protected surfaces (wp-login / register / lost-password / comments, WooCommerce my-account / checkout / pay-for-order, Ultimate Multisite checkout / inline-login) and replies with HTTP 429, a `Retry-After` header, and a randomised tarpit sleep (1–5s, hard-capped at 15s).
+* New: `cap_rate_limit_tarpit_min` / `cap_rate_limit_tarpit_max` settings to tune the tarpit window.
+* New: `wu_cap_rate_limit_whitelist_ip` filter to exempt trusted IP ranges.
+* New: `wu_cap_rate_limit_will_block` action that fires immediately before the hard-stop response is sent.
+* New: Spoof-resistant client-IP detection. `Captcha_Core::get_client_ip()` (the source of truth for rate-limit bucket keys, captcha siteverify `remoteip`, and statistics IP hashes) now enforces a strict trust model: REMOTE_ADDR is the floor, `CF-Connecting-IP` is honoured only when the immediate peer is inside a current Cloudflare IP range, and `X-Forwarded-For` is honoured only when the immediate peer is in the admin-configured trusted-proxy list, with a right-to-left walk that skips trusted/CF hops before settling on the visitor IP.
+* New: `cap_trust_cloudflare_headers` setting (default OFF) — opt into `CF-Connecting-IP` trust when behind Cloudflare. The plugin ships a bundled Cloudflare CIDR snapshot and refreshes it weekly via wp-cron with bundled fallback if the refresh fails.
+* New: `cap_trusted_proxies` setting — textarea of CIDRs or bare IPs (one per line, `#` comments allowed) listing your own front-line proxies / load-balancers. Without this, `X-Forwarded-For` is ignored even when the rate limiter is enabled.
+* New: First-enable auto-detection of likely Cloudflare / proxy posture with a one-click "Apply detected settings" admin notice. The plugin never overwrites your saved values; if subsequent traffic suggests your config no longer matches reality (e.g. Cloudflare changed CIDR ranges and your proxy CIDR is now stale), a non-dismissable mismatch notice surfaces the recommended update.
+* Fixed: Invisible mode no longer silently downgrades `cap_security_level` to FAST — the admin's configured level is honoured. A new `wu_cap_server_security_level` filter is available for sites that want bespoke logic.
+* Fixed: Statistics `rate_limits_triggered` counter now increments on every block, not only on the rare post-success backstop path.
+* Fixed: `Captcha_Core::get_client_ip()` is now the single source of truth for visitor IP attribution across the rate limiter, captcha providers (reCAPTCHA + hCaptcha `siteverify`), and statistics — closing a spoofing vector where direct origin-server requests carrying a forged `CF-Connecting-IP` header would have been bucketed by the spoofed IP instead of the real peer.
+* Fixed: WooCommerce classic checkout rate-limit gate now fires on `template_redirect` (priority 1) instead of `woocommerce_before_checkout_form`. The form-level hook never fires when the cart is empty, so flood traffic that never adds a product was bypassing the limiter entirely.
+* Fixed: WooCommerce pay-for-order rate-limit gate now fires on `template_redirect` instead of `woocommerce_before_pay_action`. The latter only fires after `wp_verify_nonce('woocommerce-pay')` succeeds, which means unauth attackers (the actual threat model) never triggered the limiter.
+* Fixed: WooCommerce Store API (blocks) checkout rate-limit gate now fires on `rest_pre_dispatch` instead of `woocommerce_store_api_checkout_update_order_from_request`. The latter only fires after Store API validates the cart and billing fields, so unauth bots got a 400 from the validator and never tripped the limiter.
+* Fixed: Ultimate Multisite inline-login rate-limit gate now fires on `wu_ajax_nopriv_wu_inline_login` priority 1 (and the logged-in mirror) instead of `wu_before_inline_login`. The latter only fires after `check_ajax_referer('wu_checkout')` succeeds, so unauth bots without a valid wu_checkout nonce got a 403 and never tripped the limiter.
+* Fixed: `Rate_Limiter::enforce()` now applies a once-per-request guard keyed by `surface|ip`, so upstream hooks that fire twice per render (notably `wu_setup_checkout` in Ultimate Multisite) no longer halve the effective rate-limit threshold.
+* Fixed: Rate-limit surface gates no longer consult `Captcha_Core::is_whitelisted()` (`wu_captcha_whitelisted` filter). That filter signals "captcha already handled by another surface" and is orthogonal to flood protection — the WooCommerce integration was hooking it to skip the WordPress login captcha when a Woo nonce was present, which bled into rate counting and let Woo POSTs avoid the limiter. The rate-limit-specific `wu_cap_rate_limit_whitelist_ip` filter is the only bypass that now applies.
+
 Version: 1.3.2 - Released on 2026-01-27
 * Fixed: Cap widget not rendering on checkout forms using Elementor or other page builders
 * Fixed: cap-widget custom element being stripped by wp_kses() sanitization

--- a/docs/addons/captcha/index.mdx
+++ b/docs/addons/captcha/index.mdx
@@ -89,3 +89,122 @@ The captcha provider is set network-wide, but you can adjust difficulty settings
 ## Is this GDPR compliant?
 
 Cap Captcha is 100% self-hosted with no data sent to external services. For Google reCAPTCHA and hCaptcha, please review their respective privacy policies.
+
+## Rate Limiting
+
+Ultimate Multisite: Captcha v1.5.0 introduces a hard-stop rate limiter that protects your network from brute-force and card-testing attacks.
+
+### How It Works
+
+The rate limiter counts every GET and POST request on captcha-protected surfaces:
+
+* **WordPress login endpoints** — wp-login, register, lost-password, comments
+* **WooCommerce checkout** — my-account, checkout, pay-for-order
+* **Ultimate Multisite** — checkout, inline-login
+
+When a visitor exceeds the rate limit, the plugin responds with:
+
+* **HTTP 429 (Too Many Requests)** status code
+* **Retry-After** header indicating when to retry
+* **Randomised tarpit sleep** (1–5 seconds by default, hard-capped at 15 seconds) to slow down attackers
+
+### Configuration
+
+#### Tarpit Timing
+
+Control the randomised delay applied to rate-limited requests:
+
+* **`cap_rate_limit_tarpit_min`** — Minimum sleep duration in seconds (default: 1)
+* **`cap_rate_limit_tarpit_max`** — Maximum sleep duration in seconds (default: 5, hard-capped at 15)
+
+These settings are available in **Ultimate Multisite → Settings → Captcha**.
+
+### Extensibility
+
+#### IP Whitelist Filter
+
+Exempt trusted IP ranges from rate limiting:
+
+```php
+add_filter( 'wu_cap_rate_limit_whitelist_ip', function( $is_whitelisted, $ip ) {
+    // Whitelist your monitoring service
+    if ( $ip === '203.0.113.42' ) {
+        return true;
+    }
+    return $is_whitelisted;
+}, 10, 2 );
+```
+
+#### Pre-Block Action
+
+Execute custom logic immediately before a rate-limit block is sent:
+
+```php
+add_action( 'wu_cap_rate_limit_will_block', function( $ip, $surface ) {
+    // Log the block, notify admins, or update custom metrics
+    error_log( "Rate limit triggered for $ip on $surface" );
+}, 10, 2 );
+```
+
+## Client IP Detection & Trusted Proxies
+
+Ultimate Multisite: Captcha v1.5.0 introduces spoof-resistant client-IP detection. The `Captcha_Core::get_client_ip()` method is now the single source of truth for visitor IP attribution across:
+
+* Rate-limit bucket keys
+* Captcha provider `remoteip` (reCAPTCHA, hCaptcha `siteverify`)
+* Statistics IP hashes
+
+### Trust Model
+
+The plugin enforces a strict IP trust hierarchy:
+
+1. **REMOTE_ADDR** — Always trusted (the immediate peer's IP)
+2. **CF-Connecting-IP** — Honoured only when:
+   - The immediate peer is inside a current Cloudflare IP range
+   - `cap_trust_cloudflare_headers` is enabled (default: OFF)
+3. **X-Forwarded-For** — Honoured only when:
+   - The immediate peer is in your admin-configured trusted-proxy list
+   - The header is parsed right-to-left, skipping trusted/Cloudflare hops
+
+### Configuration
+
+#### Cloudflare Header Trust
+
+Enable trust of Cloudflare's `CF-Connecting-IP` header:
+
+* **`cap_trust_cloudflare_headers`** — Set to ON to opt into `CF-Connecting-IP` trust
+  - Default: OFF (disabled)
+  - The plugin ships with a bundled Cloudflare CIDR snapshot
+  - CIDR ranges are refreshed weekly via wp-cron
+  - Bundled fallback is used if the refresh fails
+
+#### Trusted Proxy Configuration
+
+Define your front-line proxies and load-balancers:
+
+* **`cap_trusted_proxies`** — Textarea of CIDRs or bare IPs (one per line)
+  - Comments are allowed (lines starting with `#`)
+  - Without this setting, `X-Forwarded-For` is ignored even when the rate limiter is enabled
+  - Example:
+    ```
+    # Our load balancer
+    192.0.2.0/24
+    
+    # Backup proxy
+    198.51.100.50
+    ```
+
+#### First-Enable Auto-Detection
+
+When you first enable the rate limiter, the plugin detects your likely Cloudflare and proxy posture and displays a one-click "Apply detected settings" admin notice.
+
+* The plugin **never overwrites** your saved values
+* If subsequent traffic suggests your config no longer matches reality (e.g., Cloudflare changed CIDR ranges), a non-dismissable mismatch notice surfaces the recommended update
+
+### Why This Matters
+
+A strict IP trust model closes a critical spoofing vector: direct origin-server requests carrying a forged `CF-Connecting-IP` header would previously have been bucketed by the spoofed IP instead of the real peer. This is especially important for:
+
+* **Rate limiting** — Attackers can't bypass limits by spoofing IPs
+* **Statistics** — Your attack metrics reflect real visitor IPs, not forged ones
+* **Captcha verification** — Providers receive the correct visitor IP for risk assessment


### PR DESCRIPTION
## Summary

Added comprehensive documentation for v1.5.0 features:

- Hard-stop rate limiter with HTTP 429 responses and tarpit timing
- Rate-limit-specific IP whitelist filter and pre-block action
- Spoof-resistant client-IP detection with strict trust model
- Cloudflare header trust configuration with auto-detection
- Trusted proxy CIDR configuration with examples
- Updated changelog with all v1.5.0 features and fixes

## Files Changed

docs/addons/captcha/changelog.md,docs/addons/captcha/index.mdx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified changelog format matches existing entries; documentation sections follow existing style and structure

Resolves #106


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-haiku-4-5 spent 1m and 4,925 tokens on this as a headless worker.