### PR TITLE
GH#122: docs: update AI provider connector docs

### DIFF
--- a/docs/developer/integration-guide/custom-gateway.md
+++ b/docs/developer/integration-guide/custom-gateway.md
@@ -78,3 +78,17 @@ add_filter('wu_payment_gateways', function($gateways) {
 - Always return `WP_Error` on failure so Ultimate Multisite can handle error display
 - Set `$this->supports` to declare which payment types your gateway handles (`one-time`, `recurring`)
 - Use `wu_log_add()` for gateway-specific logging
+
+## AI connector provider capabilities
+
+Custom integrations that call AI connector-backed operations should align with the supported OAuth provider set introduced with AI Provider for Anthropic Max v1.3.0:
+
+| Provider | Capability notes |
+|---|---|
+| **Anthropic Max** | Supports the existing OAuth account pool workflow. Preserve Anthropic tool-use payloads, including empty tool arrays and round-trip thinking signatures, when proxying connector requests. |
+| **OpenAI ChatGPT/Codex** | Supports the OAuth pool workflow and full tool-support behavior for connector-supported operations. Pass tool definitions and tool-call results through without stripping Codex-specific tool metadata. |
+| **Google AI Pro** | Supports the OAuth pool workflow and SDK-backed provider integration. Refresh provider accounts after OAuth completion before routing requests. |
+
+Cursor Pro integration and setup pathways have been removed. Do not register Cursor Pro as a selectable provider or present Cursor-specific OAuth instructions in custom connector UIs.
+
+For sandboxed or headless environments, expose the manual OAuth fallback path so administrators can paste the returned authorization data and complete account connection without relying on an automatic browser redirect.

--- a/docs/user-guide/administration/settings-reference.md
+++ b/docs/user-guide/administration/settings-reference.md
@@ -24,3 +24,17 @@ If you maintain internal runbooks or screenshots for the settings page, remove r
 ## Import/Export settings
 
 The **Import/Export** settings tab describes which settings it controls and links directly to **Ultimate Multisite > Site Export** for site and network archives. Use the settings tab for import/export configuration, use **Tools > Export & Import** for the single-site export/import workflow, and use the Site Export tool when you need a full Network Export archive.
+
+## AI provider connector settings
+
+AI provider connector settings now expose only the supported OAuth account pools:
+
+| Provider | Setup flow |
+|---|---|
+| **Anthropic Max** | Connect one or more Anthropic Max accounts with the OAuth button. Use the manual OAuth fallback when a sandboxed browser cannot complete the redirect automatically. |
+| **OpenAI ChatGPT/Codex** | Connect ChatGPT accounts through the same OAuth pool workflow. Connector-supported operations can use ChatGPT Codex tool calls after the account is connected. |
+| **Google AI Pro** | Connect Google AI Pro accounts through OAuth, then refresh the connector if the account list does not update immediately. |
+
+Cursor Pro is no longer a supported provider. Remove old internal screenshots, runbooks, or onboarding steps that mention Cursor Pro setup fields or connector paths.
+
+When adding or removing provider accounts, enter a valid email address for the account being refreshed or deleted and save the provider settings before testing connector-backed operations.

--- a/docs/user-guide/administration/touring-the-admin-panel.md
+++ b/docs/user-guide/administration/touring-the-admin-panel.md
@@ -83,6 +83,10 @@ The **Domains** page is dedicated to custom domains mapped to subsites. As a sup
 
 The **Settings** page is where you configure Ultimate Multisite — registration settings, payments, API and webhooks, domain mapping, and other integrations.
 
+AI connector settings list the currently supported OAuth provider pools: Anthropic Max, OpenAI ChatGPT/Codex, and Google AI Pro. Each provider card lets super admins connect accounts, refresh saved accounts, remove accounts by email, and use the manual OAuth fallback when a sandboxed environment blocks the browser redirect. Cursor Pro setup options have been removed from the admin panel.
+
+ChatGPT/Codex accounts support connector-backed tool use where the operation allows tools, so admin workflows that depend on connector-supported operations can use Codex tool behavior after the OpenAI account is connected.
+
 ![Settings page](/img/admin/settings-general.png)
 
 Here's a full view of the general settings page:


### PR DESCRIPTION
## Summary

Updated the settings reference, admin panel tour, and custom gateway developer guide for AI Provider for Anthropic Max v1.3.0. The docs now list supported OAuth providers, note ChatGPT/Codex tool support, document Google AI Pro and manual OAuth fallback behavior, and remove Cursor Pro setup guidance.

## Files Changed

docs/developer/integration-guide/custom-gateway.md,docs/user-guide/administration/settings-reference.md,docs/user-guide/administration/touring-the-admin-panel.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run build (fails on existing broken image references outside the edited files: docs/user-guide/domain-mapping/how-to-configure-domain-mapping.md, docs/user-guide/miscellaneous/sending-emails-and-broadcasts.md, docs/user-guide/payment-gateways/getting-paid.md, docs/user-guide/payment-gateways/manual-payments.md, docs/user-guide/payment-gateways/tax-handling.md)

Resolves #122


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5m and 69,884 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded AI provider connector documentation with setup instructions for Anthropic Max, OpenAI, and Google AI Pro.
  * Added manual OAuth fallback option for headless environments.
  * Updated admin panel and settings reference guides with connector configuration details.
  * Removed Cursor Pro from supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->