### PR TITLE
GH#139: ci: skip locale planning when scheduled docs are unchanged

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -112,6 +112,8 @@ jobs:
   # ── Locale chunk planning ────────────────────────────────────────────────────
   plan-locale-chunks:
     needs: check-changes
+    # Always build on push/manual; skip scheduled runs when nothing changed.
+    if: needs.check-changes.outputs.changed == 'true' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
       chunks: ${{ steps.plan.outputs.chunks }}


### PR DESCRIPTION
## Summary

Added the same scheduled-run skip guard to the plan-locale-chunks workflow job that prepare-docs-source and build-locale-chunk already use, so unchanged scheduled runs do not spend CI minutes planning locale chunks.

## Files Changed

.github/workflows/deploy-docs.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** actionlint unavailable; verified the expected plan-locale-chunks skip condition is present with a Python check

Resolves #139


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 47,842 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized documentation deployment workflow to skip unnecessary processing on scheduled runs when no changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->