### PR TITLE
GH#121: docs: document Domain Seller 1.3.0

### DIFF
--- a/docs/addons/domain-seller/changelog.md
+++ b/docs/addons/domain-seller/changelog.md
@@ -5,6 +5,19 @@ sidebar_position: 99
 
 # Domain Seller Changelog
 
+Version 1.3.0 - Released on 2026-06-02
+- New: Added a network-admin warning when HostAfrica reseller balance gets too low
+- New: Added automatic mapping of newly registered domains to the network site
+- Fix: Applied registrant field requirements only when registering a new domain
+- Fix: Made monitor balance notices dismissible
+- Fix: Ensured WooCommerce registrant billing details are preserved
+- Fix: Enforced registrant contact requirements during registration
+- Fix: Prevented domain registration products from being created with 0% markup
+- Fix: Preserved domain selections and pricing through checkout session flow
+- Fix: Improved HostAfrica domain pricing currency display
+- Fix: Improved checkout form-action behavior to prevent WP-core query-var mismatches
+- Improved: Linked HostAfrica reseller configuration documentation in setup guidance
+
 Version 1.2.0 - Released on 2026-05-25
 - New: Added HostAfrica as a domain-selling integration with checkout, setup wizard, lookup, TLD/pricing, registration, renewal, transfer, nameserver, DNS, EPP code, registrar lock, and ID protection support
 - New: Added Openprovider as a domain-selling integration with reseller pricing, registration, renewal, transfer, nameserver, DNS, EPP code, registrar lock, WHOIS privacy, and TLD sync support

--- a/docs/user-guide/administration/settings-reference.md
+++ b/docs/user-guide/administration/settings-reference.md
@@ -25,6 +25,12 @@ If you maintain internal runbooks or screenshots for the settings page, remove r
 
 The **Import/Export** settings tab describes which settings it controls and links directly to **Ultimate Multisite > Site Export** for site and network archives. Use the settings tab for import/export configuration, use **Tools > Export & Import** for the single-site export/import workflow, and use the Site Export tool when you need a full Network Export archive.
 
+## Domain Seller HostAfrica balance warning
+
+When the Domain Seller addon is connected to HostAfrica, network administrators now see a dismissible balance-low warning when the reseller account balance is too low for reliable domain registration or renewal processing.
+
+Treat this notice as an operational warning: top up the HostAfrica reseller balance before accepting more paid domain registrations, then return to the Domain Seller settings or domain-monitoring screen to confirm registrations and renewals can continue normally.
+
 ## AI provider connector settings
 
 AI provider connector settings now expose only the supported OAuth account pools:

--- a/docs/user-guide/domain-mapping/how-to-configure-domain-mapping.md
+++ b/docs/user-guide/domain-mapping/how-to-configure-domain-mapping.md
@@ -71,6 +71,8 @@ This will start the process of verifying and fetching the DNS information of the
 
 Ultimate Multisite v2.13.0 also creates the internal domain record automatically when a new site is created on a host that should be treated as a per-site domain. If the host is the network's primary domain, or one of the shared checkout-form base domains configured on a **Site URL** field, the automatic mapped-domain record is skipped so that shared base domain remains available to every site that uses it.
 
+When a customer registers a new domain through Domain Seller v1.3.0 or newer, Ultimate Multisite automatically maps the registered domain to the customer's network site by default. Administrators no longer need to add a separate mapped-domain record after a successful registration unless they want to adjust options such as the primary-domain flag, activation state, or SSL handling.
+
 The **Stage** or the status should change from **Checking DNS** to **Ready** if everything is properly set up.
 
 <!-- Screenshot unavailable: Domain row showing the Checking DNS stage in the domains list -->


### PR DESCRIPTION
## Summary

Documented Domain Seller v1.3.0 administrator-facing changes: HostAfrica low-balance warning, automatic mapping of newly registered domains, and the addon changelog entry.

## Files Changed

docs/addons/domain-seller/changelog.md,docs/user-guide/administration/settings-reference.md,docs/user-guide/domain-mapping/how-to-configure-domain-mapping.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run build (timed out after generating en while continuing all locales); npx docusaurus build --locale en (passed)

Resolves #121


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 9m and 39,039 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release note entry highlighting recent domain-selling improvements and fixes.
  * Updated the settings reference with guidance about a dismissible low-balance warning for HostAfrica-connected accounts.
  * Clarified domain-mapping instructions so newly registered domains are automatically mapped to the customer’s network site by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->