### PR TITLE
GH#146: docs: update WooCommerce integration for 2.2.0

### DIFF
--- a/docs/addons/woocommerce/changelog.md
+++ b/docs/addons/woocommerce/changelog.md
@@ -5,6 +5,15 @@ sidebar_position: 99
 
 # WooCommerce Integration Changelog
 
+Version 2.2.0 - Released on 2026-07-01
+* New: Ultimate Multisite tax amounts now appear as separate WooCommerce fee lines at checkout, making tax totals clearer before payment.
+* New: Added an opt-in "Suspend Memberships Immediately on Failed Renewals" setting and `wu_woo_suspend_on_payment_failure` filter for sites that want failed-renewal suspension during the WooCommerce Subscriptions retry window.
+* Fix: Reconciled WooCommerce Subscription statuses that could stay out of sync with Ultimate Multisite memberships after failed or recovered renewals.
+* Fix: Added the WooCommerce store currency to the Ultimate Multisite currency list when it was missing.
+* Fix: Preserved customer billing details when redirecting subscribers to WooCommerce checkout.
+* Improved: Added compatibility with Jetpack Autoloader 5.
+* Improved: Cleaned release package generation so GitHub and marketplace zips avoid nested staging directories and development files.
+
 Version 2.0.6 - Released on 2026-01-16
 * Improvement: Include core subscriptions in the addon. No longer requires Woocommerce Subscriptinos extension.
 

--- a/docs/addons/woocommerce/index.mdx
+++ b/docs/addons/woocommerce/index.mdx
@@ -16,6 +16,7 @@ The WooCommerce Integration works in a very similar way to the way our Manual Ga
 - Easy integration between Ultimate Multisite and WooCommerce
 - Several payment methods available
 - Automated recurring billing using the bundled subscriptions core, with optional WooCommerce Subscriptions plugin enhancements
+- Checkout totals include Ultimate Multisite taxes as separate, non-taxable WooCommerce fee lines so customers can review tax amounts before payment
 
 ## Documentation
 
@@ -67,6 +68,10 @@ Once installed, you will see an additional option under the Ultimate Multisite p
 
 You can configure some basic settings like the display name that will show in the front end and instructions to guide your users in their checkout flow. Then you can go to your **Main site’s _WooCommerce_ settings** to enable and configure the payment gateway you prefer to use.
 
+### Checkout tax fee lines
+
+When an Ultimate Multisite checkout includes taxes, the integration adds each Ultimate Multisite tax amount to WooCommerce checkout as a separate, non-taxable fee line. This keeps the tax total visible before payment while preventing WooCommerce from taxing the tax fee again.
+
 ## How to manage the payment
 
 The WooCommerce Integration works in a very similar way to the way our **Manual Gateway** works. The downside is that every payment must be paid manually at the end of the billing period. Here is how the flow works:
@@ -94,3 +99,11 @@ You do **not** need to purchase or install the separate [WooCommerce Subscriptio
 And that is it. Your end-users will no longer need to manually make a payment at the end of their billing cycle for recurring products.
 
 Aside from an order being created on your main site under _WooCommerce_, it will also create a subscription for each account.
+
+### Failed renewal suspension behavior
+
+By default, memberships remain active while WooCommerce Subscriptions processes its failed-payment retry schedule. This preserves the normal WooCommerce Subscriptions grace window so a recovered renewal can bring the subscription and membership back into sync without prematurely interrupting access.
+
+Administrators who want stricter access control can enable **Suspend Memberships Immediately on Failed Renewals** in the WooCommerce Integration settings. When this opt-in setting is enabled, Ultimate Multisite suspends the related membership as soon as a renewal payment fails instead of waiting for WooCommerce Subscriptions retry handling to finish.
+
+Developers can override the same decision with the `wu_woo_suspend_on_payment_failure` filter. Hook reference pages are generated from the add-on source, so this overview only calls out the filter name for custom suspension policies.


### PR DESCRIPTION
## Summary

Updated WooCommerce Integration documentation with v2.2.0 checkout tax fee line behavior, failed-renewal suspension setting/filter details, and the 2.2.0 changelog entry.

## Files Changed

docs/addons/woocommerce/changelog.md,docs/addons/woocommerce/index.mdx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run build initially failed due missing worktree dependencies; npm install completed; full all-locale npm run build exceeded worker timeout after successful en build; npx docusaurus build --locale en passed.

Resolves #146


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 8m and 79,370 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout now shows Ultimate Multisite tax as separate fee lines, making totals clearer before payment.
  * Added an option to suspend memberships immediately after failed renewals, instead of waiting for retry attempts to finish.
  * Membership status now stays aligned with subscription recovery after failed and later successful renewals.

* **Bug Fixes**
  * Improved currency display handling.
  * Preserved billing details when sending customers to checkout.
  * Added compatibility improvements for newer autoloading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->