### PR TITLE
GH#151: fix: harden translation workflow inputs

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -43,22 +43,25 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE || secrets.OPENAI_API_BASE || 'https://api.sdaiagent.com/v1' }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL || secrets.OPENAI_MODEL || 'superdav-chat-pro' }}
+          LANGUAGES: ${{ inputs.languages }}
+          FORCE: ${{ inputs.force }}
+          DEBUG: ${{ inputs.debug }}
         run: |
-          ARGS=""
+          ARGS=()
 
-          if [ "${{ inputs.languages }}" != "all" ]; then
-            ARGS="$ARGS --locales ${{ inputs.languages }}"
+          if [ "$LANGUAGES" != "all" ]; then
+            ARGS+=(--locales "$LANGUAGES")
           fi
 
-          if [ "${{ inputs.force }}" == "true" ]; then
-            ARGS="$ARGS --force"
+          if [ "$FORCE" == "true" ]; then
+            ARGS+=(--force)
           fi
 
-          if [ "${{ inputs.debug }}" == "true" ]; then
-            ARGS="$ARGS --debug"
+          if [ "$DEBUG" == "true" ]; then
+            ARGS+=(--debug)
           fi
 
-          node scripts/translate.js --concurrency 2 --commit $ARGS
+          node scripts/translate.js --concurrency 2 --commit "${ARGS[@]}"
 
       - name: Push translations
         if: always() && !cancelled()


### PR DESCRIPTION
## Summary

Passed workflow_dispatch inputs through environment variables and used a Bash array for translate.js arguments so untrusted inputs are not template-expanded directly inside the run block.

## Files Changed

.github/workflows/translate.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck -s bash on the translated run block; git diff --check

Resolves #151


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 68,590 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the translation automation workflow to handle translation options more reliably during runs.
  * Updated how translation settings are passed through, reducing issues caused by argument formatting and making the process more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->