### PR TITLE
GH#169: docs: fix captcha checkout rate-limit defaults

### DIFF
--- a/docs/addons/captcha/index.mdx
+++ b/docs/addons/captcha/index.mdx
@@ -112,7 +112,7 @@ When a visitor exceeds the rate limit, the plugin responds with:
 
 #### Checkout Defaults
 
-Ultimate Multisite: Captcha v1.6.1 uses safer checkout rate-limit defaults: **20 attempts per 10-minute window** with a **10-minute block duration** after the limit is exceeded. This wider threshold reduces false positives for legitimate shoppers who retry checkout after payment, billing, or validation errors while still blocking abusive retry patterns used in card-testing attacks.
+Ultimate Multisite: Captcha v1.6.1 uses safer checkout rate-limit defaults: **5 attempts per 10-minute window** with a **1-hour block duration** after the limit is exceeded. This threshold reduces false positives for legitimate shoppers who retry checkout after payment, billing, or validation errors while still blocking abusive retry patterns used in card-testing attacks.
 
 #### Tarpit Timing
 


### PR DESCRIPTION
## Summary

Updated Captcha addon checkout defaults documentation to state 5 attempts per 10-minute window and a 1-hour block duration.

## Files Changed

docs/addons/captcha/index.mdx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run build -- --locale en passed. Full npm run build was attempted but exceeded 10 minutes while generating all locales after successful English and several locale builds.

Resolves #169


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 14m and 60,781 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Captcha checkout rate-limit guidance: retries are limited to 5 attempts per 10-minute window.
  * Clarified that further attempts are blocked for 1 hour after the limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->